### PR TITLE
feat: add lot summary view with integrated filter interface

### DIFF
--- a/src/components/shared/FilterSection.tsx
+++ b/src/components/shared/FilterSection.tsx
@@ -26,12 +26,18 @@ interface FilterSectionProps {
     onChange: (value: string) => void;
     lots: Lot[];
   };
+  viewFilter?: {
+    value: string;
+    onChange: (value: string) => void;
+    options: FilterOption[];
+  };
 }
 
 export default function FilterSection({
   title,
   typeFilter,
   lotFilter,
+  viewFilter,
 }: FilterSectionProps) {
   return (
     <div className="mb-6">
@@ -39,6 +45,30 @@ export default function FilterSection({
         <h1 className="text-2xl font-bold">{title}</h1>
 
         <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center">
+          {/* View Filter (optional) */}
+          {viewFilter && (
+            <div className="flex items-center space-x-2">
+              <span className="text-sm font-medium text-muted-foreground">
+                {translations.labels.view}:
+              </span>
+              <Select
+                value={viewFilter.value}
+                onValueChange={viewFilter.onChange}
+              >
+                <SelectTrigger className="w-[160px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {viewFilter.options.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
           {/* Type Filter */}
           <div className="flex items-center space-x-2">
             <Filter className="text-muted-foreground h-4 w-4" />

--- a/src/components/shared/IncomeList.tsx
+++ b/src/components/shared/IncomeList.tsx
@@ -8,9 +8,11 @@ import { translations } from "@/lib/translations";
 import ContributionModal from "../modals/ContributionModal";
 import ConfirmationModal from "../modals/ConfirmationModal";
 import { Card, CardContent } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import SummarySection from "@/components/shared/SummarySection";
 import FilterSection from "@/components/shared/FilterSection";
 import ItemCard from "@/components/shared/ItemCard";
+import LotSummaryView from "@/components/shared/LotSummaryView";
 import { ExportButton } from "@/components/shared/ExportButton";
 import { exportIncomesAction } from "@/lib/actions/export-actions";
 
@@ -35,6 +37,7 @@ export default function IncomeList({
     useState<Contribution | null>(null);
   const [selectedLotId, setSelectedLotId] = useState<string>("");
   const [incomeFilter, setIncomeFilter] = useState<IncomeType>("all");
+  const [activeTab, setActiveTab] = useState<string>("summary");
 
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -43,6 +46,7 @@ export default function IncomeList({
   useEffect(() => {
     const lotParam = searchParams.get("lot");
     const typeParam = searchParams.get("type") as IncomeType;
+    const tabParam = searchParams.get("tab");
 
     if (lotParam && lots.some((lot) => lot.id === lotParam)) {
       setSelectedLotId(lotParam);
@@ -64,6 +68,18 @@ export default function IncomeList({
       params.delete("type");
       router.replace(`?${params.toString()}`, { scroll: false });
       setIncomeFilter("all");
+    }
+
+    if (tabParam && ["list", "summary"].includes(tabParam)) {
+      setActiveTab(tabParam);
+    } else if (tabParam) {
+      // If tab in URL is invalid, clear it
+      const params = new URLSearchParams(searchParams.toString());
+      params.delete("tab");
+      router.replace(`?${params.toString()}`, { scroll: false });
+      setActiveTab("summary");
+    } else if (!tabParam) {
+      setActiveTab("summary");
     }
   }, [searchParams, lots, router]);
 
@@ -201,11 +217,46 @@ export default function IncomeList({
 
   const selectedLot = lots.find((lot) => lot.id === selectedLotId);
 
+  const handleTabChange = (tabValue: string) => {
+    setActiveTab(tabValue);
+
+    const params = new URLSearchParams(searchParams.toString());
+    if (tabValue !== "summary") {
+      params.set("tab", tabValue);
+    } else {
+      params.delete("tab");
+    }
+
+    // Update URL without causing a page refresh
+    router.replace(`?${params.toString()}`, { scroll: false });
+  };
+
+  const handleLotClickFromSummary = (lotId: string) => {
+    setActiveTab("list");
+    handleLotFilterChange(lotId);
+    
+    // Update tab in URL
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("tab", "list");
+    if (lotId) {
+      params.set("lot", lotId);
+    }
+    router.replace(`?${params.toString()}`, { scroll: false });
+  };
+
   return (
     <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
       {/* Header with unified filters and actions */}
       <FilterSection
-        title={title}
+        title="Aportes"
+        viewFilter={{
+          value: activeTab,
+          onChange: handleTabChange,
+          options: [
+            { value: "summary", label: translations.labels.summaryByLot },
+            { value: "list", label: translations.labels.list },
+          ],
+        }}
         typeFilter={{
           value: incomeFilter,
           onChange: (value) => handleIncomeFilterChange(value as IncomeType),
@@ -222,109 +273,124 @@ export default function IncomeList({
         }}
       />
 
-      {/* Lot Summary - appears when a lot is selected */}
-      {lotSummary && selectedLot && (
-        <div className="mb-6">
-          <h3 className="mb-4 text-lg font-semibold">
-            📊 {translations.labels.summary} - Lote {selectedLot.lotNumber} ({selectedLot.owner})
-          </h3>
-          <SummarySection
-            items={[
-              {
-                type: "maintenance",
-                total: lotSummary.maintenance.total,
-                show: true,
-              },
-              {
-                type: "works",
-                total: lotSummary.works.total,
-                show: true,
-              },
-            ]}
-          />
-        </div>
-      )}
-
-      {/* All Lots Summary - appears when all lots are selected */}
-      {allLotsSummary && (
-        <SummarySection
-          items={[
-            {
-              type: "maintenance",
-              total: allLotsSummary.maintenance.total,
-              show: incomeFilter === "all" || incomeFilter === "maintenance",
-            },
-            {
-              type: "works",
-              total: allLotsSummary.works.total,
-              show: incomeFilter === "all" || incomeFilter === "works",
-            },
-          ]}
-        />
-      )}
-
-      {/* Income List Card */}
-      <Card>
-        <CardContent className="p-6">
-          {/* Results Header */}
-          <div className="mb-4 flex items-center justify-between">
-            <div>
-              <p className="text-sm text-gray-600">
-                {filteredContributions.length}{" "}
-                {filteredContributions.length === 1
-                  ? translations.labels.result
-                  : translations.labels.results}
-              </p>
-            </div>
-            {isAuthenticated && (
-              <ExportButton 
-                onExport={exportIncomesAction}
-                variant="outline"
-                size="sm"
-              >
-                {translations.actions.export} {translations.labels.income} CSV
-              </ExportButton>
-            )}
-          </div>
-
-          <div className="space-y-3">
-            {filteredContributions.map((contribution) => {
-              const lot = getLotInfo(contribution.lotId);
-              return (
-                <ItemCard
-                  key={contribution.id}
-                  id={contribution.id}
-                  date={contribution.date}
-                  title={`Lote ${lot?.lotNumber} - ${lot?.owner}`}
-                  type={contribution.type}
-                  amount={contribution.amount}
-                  description={contribution.description}
-                  receiptNumber={contribution.receiptNumber}
-                  amountColorClass="text-emerald-600"
-                  isAuthenticated={isAuthenticated}
-                  onEdit={() => setEditingContribution(contribution)}
-                  onDelete={() => setDeletingContribution(contribution)}
-                  editTitle={translations.actions.edit}
-                  deleteTitle={translations.actions.delete}
+      <div className="mt-6">
+        {activeTab === "list" && (
+          <div>
+            {/* Lot Summary - appears when a lot is selected */}
+            {lotSummary && selectedLot && (
+              <div className="mb-6">
+                <h3 className="mb-4 text-lg font-semibold">
+                  📊 {translations.labels.summary} - Lote {selectedLot.lotNumber} ({selectedLot.owner})
+                </h3>
+                <SummarySection
+                  items={[
+                    {
+                      type: "maintenance",
+                      total: lotSummary.maintenance.total,
+                      show: true,
+                    },
+                    {
+                      type: "works",
+                      total: lotSummary.works.total,
+                      show: true,
+                    },
+                  ]}
                 />
-              );
-            })}
-            {filteredContributions.length === 0 && (
-              <div className="py-12 text-center">
-                <div className="text-muted-foreground mb-4 text-6xl">📊</div>
-                <p className="text-muted-foreground mb-2 text-lg">
-                  {selectedLotId
-                    ? translations.messages.noContributionsForLot
-                    : translations.messages.noContributions}
-                </p>
-                <p className="text-muted-foreground text-sm">
-                  {incomeFilter !== "all" && translations.messages.changeFilter}
-                </p>
               </div>
             )}
+
+            {/* All Lots Summary - appears when all lots are selected */}
+            {allLotsSummary && (
+              <SummarySection
+                items={[
+                  {
+                    type: "maintenance",
+                    total: allLotsSummary.maintenance.total,
+                    show: incomeFilter === "all" || incomeFilter === "maintenance",
+                  },
+                  {
+                    type: "works",
+                    total: allLotsSummary.works.total,
+                    show: incomeFilter === "all" || incomeFilter === "works",
+                  },
+                ]}
+              />
+            )}
+
+            {/* Income List Card */}
+            <Card>
+              <CardContent className="p-6">
+                {/* Results Header */}
+                <div className="mb-4 flex items-center justify-between">
+                  <div>
+                    <p className="text-sm text-gray-600">
+                      {filteredContributions.length}{" "}
+                      {filteredContributions.length === 1
+                        ? translations.labels.result
+                        : translations.labels.results}
+                    </p>
+                  </div>
+                  {isAuthenticated && (
+                    <ExportButton 
+                      onExport={exportIncomesAction}
+                      variant="outline"
+                      size="sm"
+                    >
+                      {translations.actions.export} {translations.labels.income} CSV
+                    </ExportButton>
+                  )}
+                </div>
+
+                <div className="space-y-3">
+                  {filteredContributions.map((contribution) => {
+                    const lot = getLotInfo(contribution.lotId);
+                    return (
+                      <ItemCard
+                        key={contribution.id}
+                        id={contribution.id}
+                        date={contribution.date}
+                        title={`Lote ${lot?.lotNumber} - ${lot?.owner}`}
+                        type={contribution.type}
+                        amount={contribution.amount}
+                        description={contribution.description}
+                        receiptNumber={contribution.receiptNumber}
+                        amountColorClass="text-emerald-600"
+                        isAuthenticated={isAuthenticated}
+                        onEdit={() => setEditingContribution(contribution)}
+                        onDelete={() => setDeletingContribution(contribution)}
+                        editTitle={translations.actions.edit}
+                        deleteTitle={translations.actions.delete}
+                      />
+                    );
+                  })}
+                  {filteredContributions.length === 0 && (
+                    <div className="py-12 text-center">
+                      <div className="text-muted-foreground mb-4 text-6xl">📊</div>
+                      <p className="text-muted-foreground mb-2 text-lg">
+                        {selectedLotId
+                          ? translations.messages.noContributionsForLot
+                          : translations.messages.noContributions}
+                      </p>
+                      <p className="text-muted-foreground text-sm">
+                        {incomeFilter !== "all" && translations.messages.changeFilter}
+                      </p>
+                    </div>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
           </div>
-        </CardContent>
-      </Card>
+        )}
+
+        {activeTab === "summary" && (
+          <LotSummaryView
+            lots={lots}
+            contributions={contributions}
+            incomeFilter={incomeFilter}
+            onLotClick={handleLotClickFromSummary}
+          />
+        )}
+      </div>
 
       {/* Edit Modal */}
       {editingContribution && isAuthenticated && (

--- a/src/components/shared/LotSummaryTable.tsx
+++ b/src/components/shared/LotSummaryTable.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { ChevronUp, ChevronDown } from "lucide-react";
+import { Lot } from "@/types/lots.types";
+import { Contribution } from "@/types/contributions.types";
+import { translations } from "@/lib/translations";
+import { formatCurrency } from "@/lib/utils";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+interface LotSummaryData {
+  lot: Lot;
+  maintenanceTotal: number;
+  worksTotal: number;
+  total: number;
+}
+
+interface LotSummaryTableProps {
+  lots: Lot[];
+  contributions: Contribution[];
+  onLotClick?: (lotId: string) => void;
+}
+
+type SortField = 'lotNumber' | 'owner' | 'maintenanceTotal' | 'worksTotal' | 'total';
+type SortDirection = 'asc' | 'desc';
+
+export default function LotSummaryTable({
+  lots,
+  contributions,
+  onLotClick,
+}: LotSummaryTableProps) {
+  const [sortField, setSortField] = useState<SortField>('lotNumber');
+  const [sortDirection, setSortDirection] = useState<SortDirection>('asc');
+
+  const lotSummaryData = useMemo(() => {
+    const data: LotSummaryData[] = lots.map((lot) => {
+      const lotContributions = contributions.filter((c) => c.lotId === lot.id);
+      const maintenanceTotal = lotContributions
+        .filter((c) => c.type === 'maintenance')
+        .reduce((sum, c) => sum + c.amount, 0);
+      const worksTotal = lotContributions
+        .filter((c) => c.type === 'works')
+        .reduce((sum, c) => sum + c.amount, 0);
+
+      return {
+        lot,
+        maintenanceTotal,
+        worksTotal,
+        total: maintenanceTotal + worksTotal,
+      };
+    });
+
+    // Sort data
+    return data.sort((a, b) => {
+      let aValue: string | number;
+      let bValue: string | number;
+
+      switch (sortField) {
+        case 'lotNumber':
+          aValue = a.lot.lotNumber;
+          bValue = b.lot.lotNumber;
+          break;
+        case 'owner':
+          aValue = a.lot.owner;
+          bValue = b.lot.owner;
+          break;
+        case 'maintenanceTotal':
+          aValue = a.maintenanceTotal;
+          bValue = b.maintenanceTotal;
+          break;
+        case 'worksTotal':
+          aValue = a.worksTotal;
+          bValue = b.worksTotal;
+          break;
+        case 'total':
+          aValue = a.total;
+          bValue = b.total;
+          break;
+        default:
+          aValue = a.lot.lotNumber;
+          bValue = b.lot.lotNumber;
+      }
+
+      if (typeof aValue === 'string' && typeof bValue === 'string') {
+        const comparison = aValue.localeCompare(bValue, undefined, { numeric: true });
+        return sortDirection === 'asc' ? comparison : -comparison;
+      }
+
+      if (typeof aValue === 'number' && typeof bValue === 'number') {
+        return sortDirection === 'asc' ? aValue - bValue : bValue - aValue;
+      }
+
+      return 0;
+    });
+  }, [lots, contributions, sortField, sortDirection]);
+
+  const handleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortField(field);
+      setSortDirection('asc');
+    }
+  };
+
+  const getSortIcon = (field: SortField) => {
+    if (sortField !== field) return null;
+    return sortDirection === 'asc' ? (
+      <ChevronUp className="ml-1 h-4 w-4" />
+    ) : (
+      <ChevronDown className="ml-1 h-4 w-4" />
+    );
+  };
+
+  const handleRowClick = (lotId: string) => {
+    if (onLotClick) {
+      onLotClick(lotId);
+    }
+  };
+
+  return (
+    <div className="overflow-x-auto">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead
+              className="cursor-pointer select-none hover:bg-muted/50"
+              onClick={() => handleSort('lotNumber')}
+            >
+              <div className="flex items-center">
+                {translations.labels.lot}
+                {getSortIcon('lotNumber')}
+              </div>
+            </TableHead>
+            <TableHead
+              className="cursor-pointer select-none hover:bg-muted/50"
+              onClick={() => handleSort('owner')}
+            >
+              <div className="flex items-center">
+                {translations.labels.owner}
+                {getSortIcon('owner')}
+              </div>
+            </TableHead>
+            <TableHead
+              className="cursor-pointer select-none hover:bg-muted/50 text-right"
+              onClick={() => handleSort('maintenanceTotal')}
+            >
+              <div className="flex items-center justify-end">
+                {translations.labels.maintenance}
+                {getSortIcon('maintenanceTotal')}
+              </div>
+            </TableHead>
+            <TableHead
+              className="cursor-pointer select-none hover:bg-muted/50 text-right"
+              onClick={() => handleSort('worksTotal')}
+            >
+              <div className="flex items-center justify-end">
+                {translations.labels.works}
+                {getSortIcon('worksTotal')}
+              </div>
+            </TableHead>
+            <TableHead
+              className="cursor-pointer select-none hover:bg-muted/50 text-right"
+              onClick={() => handleSort('total')}
+            >
+              <div className="flex items-center justify-end font-semibold">
+                {translations.labels.total}
+                {getSortIcon('total')}
+              </div>
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {lotSummaryData.map((data) => (
+            <TableRow
+              key={data.lot.id}
+              className={`${
+                onLotClick ? 'cursor-pointer hover:bg-muted/30' : ''
+              } transition-colors`}
+              onClick={() => handleRowClick(data.lot.id)}
+            >
+              <TableCell className="font-medium">
+                {data.lot.lotNumber}
+              </TableCell>
+              <TableCell className="max-w-0 truncate">
+                {data.lot.owner}
+              </TableCell>
+              <TableCell className="text-right font-medium text-blue-600">
+                {data.maintenanceTotal > 0 ? formatCurrency(data.maintenanceTotal) : '-'}
+              </TableCell>
+              <TableCell className="text-right font-medium text-amber-600">
+                {data.worksTotal > 0 ? formatCurrency(data.worksTotal) : '-'}
+              </TableCell>
+              <TableCell className="text-right font-bold text-emerald-600">
+                {data.total > 0 ? formatCurrency(data.total) : '-'}
+              </TableCell>
+            </TableRow>
+          ))}
+          {lotSummaryData.length === 0 && (
+            <TableRow>
+              <TableCell colSpan={5} className="text-center py-8 text-muted-foreground">
+                {translations.messages.noLots || 'No hay lotes disponibles'}
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/components/shared/LotSummaryView.tsx
+++ b/src/components/shared/LotSummaryView.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useMemo } from "react";
+import { Lot } from "@/types/lots.types";
+import { Contribution, ContributionType } from "@/types/contributions.types";
+import { translations } from "@/lib/translations";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import LotSummaryTable from "./LotSummaryTable";
+import SummarySection from "./SummarySection";
+
+interface LotSummaryViewProps {
+  lots: Lot[];
+  contributions: Contribution[];
+  incomeFilter: "all" | "maintenance" | "works";
+  onLotClick?: (lotId: string) => void;
+}
+
+export default function LotSummaryView({
+  lots,
+  contributions,
+  incomeFilter,
+  onLotClick,
+}: LotSummaryViewProps) {
+  
+  // Filter contributions based on income filter
+  const filteredContributions = useMemo(() => {
+    if (incomeFilter === "all") {
+      return contributions;
+    }
+    return contributions.filter((c) => c.type === incomeFilter);
+  }, [contributions, incomeFilter]);
+
+  // Calculate summary data for overview cards
+  const summaryData = useMemo(() => {
+    const maintenanceContributions = filteredContributions.filter(
+      (c) => c.type === "maintenance"
+    );
+    const worksContributions = filteredContributions.filter(
+      (c) => c.type === "works"
+    );
+
+    const activeLots = new Set(filteredContributions.map(c => c.lotId)).size;
+
+    return {
+      maintenance: {
+        count: maintenanceContributions.length,
+        total: maintenanceContributions.reduce((sum, c) => sum + c.amount, 0),
+      },
+      works: {
+        count: worksContributions.length,
+        total: worksContributions.reduce((sum, c) => sum + c.amount, 0),
+      },
+      activeLots,
+    };
+  }, [filteredContributions]);
+
+  return (
+    <div className="space-y-6">
+      {/* Overview Summary Cards */}
+      <SummarySection
+        items={[
+          {
+            type: "maintenance",
+            total: summaryData.maintenance.total,
+            show: incomeFilter === "all" || incomeFilter === "maintenance",
+          },
+          {
+            type: "works",
+            total: summaryData.works.total,
+            show: incomeFilter === "all" || incomeFilter === "works",
+          },
+        ]}
+      />
+
+      {/* Lot Summary Table */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">
+            📋 {translations.labels.lotDetail}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          <LotSummaryTable
+            lots={lots}
+            contributions={filteredContributions}
+            onLotClick={onLotClick}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -64,6 +64,10 @@ export const translations = {
     results: "resultados",
     result: "resultado",
     summary: "Resumen",
+    summaryByLot: "Resumen por Lote",
+    lotDetail: "Detalle por Lote",
+    list: "Lista",
+    view: "Vista",
   },
 
   // Status messages


### PR DESCRIPTION
## Summary
- ✅ Add new "Summary by Lot" view alongside existing list view
- ✅ Implement responsive 5-column sortable table 
- ✅ Integrate view selection as dropdown filter (no separate tabs)
- ✅ Enable click-to-navigate from summary to filtered list
- ✅ Maintain URL state synchronization for all filters
- ✅ Update page title from "Ingresos" to "Aportes"

## UI/UX Improvements
- **Simplified header**: Removed redundant "Ingresos" title 
- **Unified filters**: View selection integrated with existing filters
- **Responsive table**: Only essential columns (Lote | Propietario | Mantenimiento | Obras | Total)
- **Smart navigation**: Click lot → auto-switch to list view with filter applied

## Technical Details
- Created `LotSummaryTable.tsx` with sortable columns and click handlers
- Created `LotSummaryView.tsx` container with summary cards
- Extended `FilterSection.tsx` to support view selection dropdown
- Updated translations for new labels and view options
- Maintained all existing functionality and URL state management

## Test plan
- [x] View switcher works and updates URL correctly
- [x] Table sorting functions for all columns
- [x] Click navigation from summary to list works
- [x] All existing filters continue to work
- [x] Responsive design works on mobile
- [x] URL state persists on page refresh

🤖 Generated with [Claude Code](https://claude.ai/code)