### PR TITLE
Move action buttons to pages and allow zero amount contributions

### DIFF
--- a/src/app/income/page.tsx
+++ b/src/app/income/page.tsx
@@ -15,7 +15,6 @@ export default async function IncomePage() {
 
     return (
       <IncomeView
-        title={translations.navigation.income}
         lots={lots}
         contributions={contributions}
         isAuthenticated={isAdmin}

--- a/src/components/shared/ExpenseList.tsx
+++ b/src/components/shared/ExpenseList.tsx
@@ -12,6 +12,7 @@ import FilterSection from "@/components/shared/FilterSection";
 import ItemCard from "@/components/shared/ItemCard";
 import { ExportButton } from "@/components/shared/ExportButton";
 import { exportExpensesAction } from "@/lib/actions/export-actions";
+import NewExpenseButton from "@/components/shared/NewExpenseButton";
 
 interface ExpenseListProps {
   title: string;
@@ -115,6 +116,9 @@ export default function ExpenseList({ title, expenses, isAuthenticated = false }
       {/* Header with filters */}
       <FilterSection
         title={title}
+        actionButton={
+          <NewExpenseButton isAuthenticated={isAuthenticated} />
+        }
         typeFilter={{
           value: expenseFilter,
           onChange: (value) => handleExpenseFilterChange(value as ExpenseType),

--- a/src/components/shared/FilterSection.tsx
+++ b/src/components/shared/FilterSection.tsx
@@ -31,6 +31,7 @@ interface FilterSectionProps {
     onChange: (value: string) => void;
     options: FilterOption[];
   };
+  actionButton?: React.ReactNode;
 }
 
 export default function FilterSection({
@@ -38,11 +39,15 @@ export default function FilterSection({
   typeFilter,
   lotFilter,
   viewFilter,
+  actionButton,
 }: FilterSectionProps) {
   return (
     <div className="mb-6">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <h1 className="text-2xl font-bold">{title}</h1>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
+          <h1 className="text-2xl font-bold">{title}</h1>
+          {actionButton}
+        </div>
 
         <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center">
           {/* View Filter (optional) */}

--- a/src/components/shared/IncomeView.tsx
+++ b/src/components/shared/IncomeView.tsx
@@ -10,9 +10,9 @@ import ConfirmationModal from "../modals/ConfirmationModal";
 import FilterSection from "@/components/shared/FilterSection";
 import IncomeList, { IncomeType } from "@/components/shared/IncomeList";
 import IncomeTable from "@/components/shared/IncomeTable";
+import NewContributionButton from "@/components/shared/NewContributionButton";
 
 interface IncomeViewProps {
-  title: string;
   contributions: Contribution[];
   lots: Lot[];
   isAuthenticated?: boolean;
@@ -20,7 +20,6 @@ interface IncomeViewProps {
 
 
 export default function IncomeView({
-  title,
   contributions,
   lots,
   isAuthenticated = false,
@@ -114,10 +113,7 @@ export default function IncomeView({
     return lots.find((lot) => lot.id === lotId);
   };
 
-  const handleContributionSuccess = (
-    contribution: Contribution,
-    isUpdate: boolean
-  ) => {
+  const handleContributionSuccess = () => {
     setEditingContribution(null);
   };
 
@@ -168,6 +164,12 @@ export default function IncomeView({
       {/* Header with unified filters and actions */}
       <FilterSection
         title="Aportes"
+        actionButton={
+          <NewContributionButton 
+            isAuthenticated={isAuthenticated}
+            lots={lots}
+          />
+        }
         viewFilter={{
           value: activeTab,
           onChange: handleTabChange,

--- a/src/components/shared/Navigation.tsx
+++ b/src/components/shared/Navigation.tsx
@@ -13,7 +13,6 @@ import {
 import { translations } from "@/lib/translations";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import ActionButtons from "./ActionButtons";
 
 interface NavigationProps {
   isAuthenticated?: boolean;
@@ -102,10 +101,6 @@ export default function Navigation({ isAuthenticated = false }: NavigationProps)
             <Menu className="h-5 w-5" />
           </Button>
 
-          {/* Action Buttons - Hidden on mobile when menu is closed */}
-          <div className="hidden sm:flex">
-            <ActionButtons isAuthenticated={isAuthenticated} />
-          </div>
         </div>
 
         {/* Mobile Navigation Menu */}
@@ -149,9 +144,6 @@ export default function Navigation({ isAuthenticated = false }: NavigationProps)
                 );
               })}
             </nav>
-            <div className="border-t border-gray-200 px-4 py-3">
-              <ActionButtons isAuthenticated={isAuthenticated} />
-            </div>
           </div>
         )}
       </div>

--- a/src/components/shared/NewContributionButton.tsx
+++ b/src/components/shared/NewContributionButton.tsx
@@ -3,33 +3,27 @@
 import { useState } from "react";
 import { Plus } from "lucide-react";
 import ContributionModal from "../modals/ContributionModal";
-import ExpenseModal from "../modals/ExpenseModal";
 import Spinner from "../ui/Spinner";
 import { Button } from "@/components/ui/button";
-import { Contribution } from "@/types/contributions.types";
-import { Expense } from "@/types/expenses.types";
 import { Lot } from "@/types/lots.types";
 import { translations } from "@/lib/translations";
 
-interface ActionButtonsProps {
+interface NewContributionButtonProps {
   isAuthenticated?: boolean;
+  lots?: Lot[];
 }
 
-export default function ActionButtons({ isAuthenticated = false }: ActionButtonsProps) {
+export default function NewContributionButton({ 
+  isAuthenticated = false,
+  lots: propLots = []
+}: NewContributionButtonProps) {
   const [showContributionModal, setShowContributionModal] = useState(false);
-  const [showExpenseModal, setShowExpenseModal] = useState(false);
-  const [lots, setLots] = useState<Lot[]>([]);
+  const [lots, setLots] = useState<Lot[]>(propLots);
   const [lotsLoading, setLotsLoading] = useState(false);
 
-  const handleContributionSuccess = (
-    contribution: Contribution,
-    isUpdate: boolean
-  ) => {
+  const handleContributionSuccess = () => {
     // The server action handles the database update and revalidation
-  };
-
-  const handleExpenseSuccess = (expense: Expense, isUpdate: boolean) => {
-    // The server action handles the database update and revalidation
+    setShowContributionModal(false);
   };
 
   const loadLots = async () => {
@@ -59,35 +53,23 @@ export default function ActionButtons({ isAuthenticated = false }: ActionButtons
 
   return (
     <>
-      <div className="flex space-x-2 py-2">
-        <Button
-          onClick={handleOpenContributionModal}
-          disabled={lotsLoading}
-          variant="default"
-        >
-          {lotsLoading ? <Spinner size="sm" /> : <Plus className="h-4 w-4" />}
-          <span>{translations.titles.newContribution}</span>
-        </Button>
-        <Button onClick={() => setShowExpenseModal(true)} variant="secondary">
-          <Plus className="h-4 w-4" />
-          <span>{translations.titles.newExpense}</span>
-        </Button>
-      </div>
+      <Button
+        onClick={handleOpenContributionModal}
+        disabled={lotsLoading}
+        variant="default"
+        size="sm"
+      >
+        {lotsLoading ? <Spinner size="sm" /> : <Plus className="h-4 w-4" />}
+        <span>{translations.titles.newContribution}</span>
+      </Button>
 
-      {/* Modals */}
+      {/* Modal */}
       {showContributionModal && (
         <ContributionModal
           onClose={() => setShowContributionModal(false)}
           onSuccess={handleContributionSuccess}
           lots={lots}
           lotsLoading={lotsLoading}
-        />
-      )}
-
-      {showExpenseModal && (
-        <ExpenseModal
-          onClose={() => setShowExpenseModal(false)}
-          onSuccess={handleExpenseSuccess}
         />
       )}
     </>

--- a/src/components/shared/NewExpenseButton.tsx
+++ b/src/components/shared/NewExpenseButton.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState } from "react";
+import { Plus } from "lucide-react";
+import ExpenseModal from "../modals/ExpenseModal";
+import { Button } from "@/components/ui/button";
+import { translations } from "@/lib/translations";
+
+interface NewExpenseButtonProps {
+  isAuthenticated?: boolean;
+}
+
+export default function NewExpenseButton({ 
+  isAuthenticated = false
+}: NewExpenseButtonProps) {
+  const [showExpenseModal, setShowExpenseModal] = useState(false);
+
+  const handleExpenseSuccess = () => {
+    // The server action handles the database update and revalidation
+    setShowExpenseModal(false);
+  };
+
+  if (!isAuthenticated) {
+    return null;
+  }
+
+  return (
+    <>
+      <Button 
+        onClick={() => setShowExpenseModal(true)} 
+        variant="default"
+        size="sm"
+      >
+        <Plus className="h-4 w-4" />
+        <span>{translations.titles.newExpense}</span>
+      </Button>
+
+      {/* Modal */}
+      {showExpenseModal && (
+        <ExpenseModal
+          onClose={() => setShowExpenseModal(false)}
+          onSuccess={handleExpenseSuccess}
+        />
+      )}
+    </>
+  );
+}

--- a/src/lib/actions/contribution-actions.ts
+++ b/src/lib/actions/contribution-actions.ts
@@ -14,7 +14,7 @@ const ContributionSchema = z.object({
   type: z.enum(["maintenance", "works", "others"], {
     message: translations.errors.typeRequired,
   }),
-  amount: z.coerce.number().positive(translations.errors.amountPositive),
+  amount: z.coerce.number().min(0, translations.errors.amountPositive),
   date: z.string().min(1, translations.errors.dateValid),
   description: z.string().optional(),
   receiptNumber: z.string().optional(),

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -246,7 +246,7 @@ export const translations = {
     lotRequired: "El lote es requerido",
     typeRequired: "El tipo debe ser mantenimiento u obras",
     amountRequired: "El monto es requerido",
-    amountPositive: "El monto debe ser positivo",
+    amountPositive: "El monto debe ser mayor o igual a cero",
     dateRequired: "La fecha es requerida",
     dateValid: "Fecha válida es requerida",
     categoryRequired: "La categoría es requerida",


### PR DESCRIPTION
## Summary
- Move 'Nuevo Aporte' button from navigation to Income page (/income)
- Move 'Nuevo Gasto' button from navigation to Expenses page (/expenses)
- Allow contributions with amount >= 0 to support in-kind contributions and cross-referenced expenses

## Changes Made
- **Enhanced FilterSection component**: Added actionButton prop to display buttons alongside page titles
- **Created NewContributionButton component**: Handles contribution modal and lots loading for Income page
- **Created NewExpenseButton component**: Handles expense modal for Expenses page
- **Updated IncomeView**: Now includes the new contribution button in the header
- **Updated ExpenseList**: Now includes the new expense button in the header
- **Removed ActionButtons from Navigation**: Cleaned up the nav bar since buttons are now on individual pages
- **Updated contribution validation**: Changed from .positive() to .min(0) to allow zero amounts
- **Updated validation message**: Changed to "El monto debe ser mayor o igual a cero"

## Test plan
- [x] Verify buttons appear on their respective pages
- [x] Verify buttons are removed from navigation
- [x] Test creating contributions with zero amounts
- [x] Run linting and type checking
- [x] Build project successfully

🤖 Generated with [Claude Code](https://claude.ai/code)