### PR TITLE
feat: add year filter for income contributions

### DIFF
--- a/src/components/shared/FilterSection.tsx
+++ b/src/components/shared/FilterSection.tsx
@@ -31,6 +31,11 @@ interface FilterSectionProps {
     onChange: (value: string) => void;
     options: FilterOption[];
   };
+  yearFilter?: {
+    value: string;
+    onChange: (value: string) => void;
+    options: FilterOption[];
+  };
   actionButton?: React.ReactNode;
 }
 
@@ -39,6 +44,7 @@ export default function FilterSection({
   typeFilter,
   lotFilter,
   viewFilter,
+  yearFilter,
   actionButton,
 }: FilterSectionProps) {
   return (
@@ -89,6 +95,27 @@ export default function FilterSection({
                 </SelectTrigger>
                 <SelectContent>
                   {typeFilter.options.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {/* Year Filter (optional) */}
+          {yearFilter && (
+            <div className="flex items-center space-x-2">
+              <Select
+                value={yearFilter.value}
+                onValueChange={yearFilter.onChange}
+              >
+                <SelectTrigger className="w-[140px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {yearFilter.options.map((option) => (
                     <SelectItem key={option.value} value={option.value}>
                       {option.label}
                     </SelectItem>

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -101,6 +101,7 @@ export const translations = {
     allIncome: "Todos los Ingresos",
     allLots: "Todos los Lotes",
     allExpenses: "Todos los Gastos",
+    allYears: "Todos los Años",
   },
 
   // Modal and form titles


### PR DESCRIPTION
## Summary
- Added year filter dropdown to income section alongside existing type and lot filters
- Year filter automatically extracts available years from contribution dates
- Filter syncs with URL parameters for persistence and bookmarking
- Works across both list view and summary by lot view
- Added Spanish translations for "All Years" filter option

## Test plan
- [x] Verify year filter dropdown appears in income section
- [x] Test filtering by different years updates the displayed data
- [x] Confirm URL parameters update when year filter changes
- [x] Check that existing filters (type, lot, view) continue to work properly
- [x] Verify year filter works in both list and summary views
- [x] Test build passes without errors

🤖 Generated with [Claude Code](https://claude.ai/code)