### PR TITLE
feat: unify expense types as general expenses

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,7 +37,7 @@ model Contribution {
 
 model Expense {
   id              Int     @id @default(autoincrement())
-  type            String
+  type            String  @default("general")
   amount          Int
   date            String
   description     String

--- a/src/components/modals/ExpenseModal.tsx
+++ b/src/components/modals/ExpenseModal.tsx
@@ -19,13 +19,6 @@ import {
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
 import { Label } from "@/components/ui/Label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/Select";
 import { FileUpload } from "@/components/ui/FileUpload";
 import { cn, formatDateForStorage } from "@/lib/utils";
 
@@ -79,7 +72,7 @@ export default function ExpenseModal({
       startTransition(() => {
         const updatedExpense: Expense = {
           id: expense?.id || 0,
-          type: formData.get("type") as "maintenance" | "works",
+          type: "general",
           amount: parseFloat(formData.get("amount") as string),
           date: formData.get("date") as string,
           description: formData.get("description") as string,
@@ -124,32 +117,7 @@ export default function ExpenseModal({
           )}
 
           {expense && <input type="hidden" name="id" value={expense.id} />}
-          <div className="space-y-2">
-            <Label htmlFor="type">{translations.labels.type}</Label>
-            <Select
-              name="type"
-              defaultValue={expense?.type || "maintenance"}
-              required
-              disabled={isSubmitting}
-            >
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="maintenance">
-                  {translations.labels.maintenance}
-                </SelectItem>
-                <SelectItem value="works">
-                  {translations.labels.works}
-                </SelectItem>
-              </SelectContent>
-            </Select>
-            {state.errors?.type && (
-              <div className="text-destructive text-sm">
-                {state.errors.type}
-              </div>
-            )}
-          </div>
+          <input type="hidden" name="type" value="general" />
 
           <div className="space-y-2">
             <Label htmlFor="amount">{translations.labels.amount}</Label>

--- a/src/components/shared/ExpenseView.tsx
+++ b/src/components/shared/ExpenseView.tsx
@@ -18,12 +18,11 @@ interface ExpenseViewProps {
   isAuthenticated?: boolean;
 }
 
-type ExpenseType = "all" | "maintenance" | "works" | "others";
+type ExpenseType = "all";
 
 export default function ExpenseView({ title, expenses, isAuthenticated = false }: ExpenseViewProps) {
   const [editingExpense, setEditingExpense] = useState<Expense | null>(null);
   const [deletingExpense, setDeletingExpense] = useState<Expense | null>(null);
-  const [expenseFilter, setExpenseFilter] = useState<ExpenseType>("all");
   const [yearFilter, setYearFilter] = useState<string>("all");
 
   const searchParams = useSearchParams();
@@ -31,14 +30,7 @@ export default function ExpenseView({ title, expenses, isAuthenticated = false }
 
   // Initialize filters from URL parameters
   useEffect(() => {
-    const typeParam = searchParams.get("type") as ExpenseType;
     const yearParam = searchParams.get("year");
-
-    if (typeParam && (typeParam === "maintenance" || typeParam === "works" || typeParam === "others")) {
-      setExpenseFilter(typeParam);
-    } else {
-      setExpenseFilter("all");
-    }
 
     if (yearParam) {
       setYearFilter(yearParam);
@@ -46,20 +38,6 @@ export default function ExpenseView({ title, expenses, isAuthenticated = false }
       setYearFilter("all");
     }
   }, [searchParams]);
-
-  const handleExpenseFilterChange = (expenseType: ExpenseType) => {
-    setExpenseFilter(expenseType);
-
-    const params = new URLSearchParams(searchParams.toString());
-    if (expenseType !== "all") {
-      params.set("type", expenseType);
-    } else {
-      params.delete("type");
-    }
-
-    // Update URL without causing a page refresh
-    router.replace(`?${params.toString()}`, { scroll: false });
-  };
 
   const handleYearFilterChange = (year: string) => {
     setYearFilter(year);
@@ -95,11 +73,6 @@ export default function ExpenseView({ title, expenses, isAuthenticated = false }
   const filteredExpenses = useMemo(() => {
     let filtered = expenses;
     
-    // Filter by expense type
-    if (expenseFilter !== "all") {
-      filtered = filtered.filter((expense) => expense.type === expenseFilter);
-    }
-    
     // Filter by year
     if (yearFilter !== "all") {
       filtered = filtered.filter(expense => {
@@ -110,7 +83,7 @@ export default function ExpenseView({ title, expenses, isAuthenticated = false }
     
     // Sort by date (most recent first)
     return filtered.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
-  }, [expenses, expenseFilter, yearFilter]);
+  }, [expenses, yearFilter]);
 
 
   const handleExpenseSuccess = (expense: Expense, isUpdate: boolean) => {
@@ -151,16 +124,6 @@ export default function ExpenseView({ title, expenses, isAuthenticated = false }
             </div>
           ) : null
         }
-        typeFilter={{
-          value: expenseFilter,
-          onChange: (value) => handleExpenseFilterChange(value as ExpenseType),
-          options: [
-            { value: "all", label: translations.filters.allExpenses },
-            { value: "maintenance", label: translations.labels.maintenance },
-            { value: "works", label: translations.labels.works },
-            { value: "others", label: translations.labels.others },
-          ],
-        }}
         yearFilter={{
           value: yearFilter,
           onChange: handleYearFilterChange,
@@ -171,7 +134,6 @@ export default function ExpenseView({ title, expenses, isAuthenticated = false }
       {/* Expenses Table */}
       <ExpenseTable
         expenses={filteredExpenses}
-        expenseFilter={expenseFilter}
         isAuthenticated={isAuthenticated}
         onEdit={setEditingExpense}
         onDelete={setDeletingExpense}

--- a/src/lib/actions/export-actions.ts
+++ b/src/lib/actions/export-actions.ts
@@ -119,7 +119,7 @@ export async function exportExpensesAction(): Promise<{
     const csvData = expenses.map((expense) => [
       expense.id.toString(),
       formatDate(expense.date),
-      expense.type === "maintenance" ? "Mantenimiento" : "Obras",
+      "Gasto General",
       expense.category,
       expense.description,
       expense.receiptNumber || "",

--- a/src/lib/database/expenses.ts
+++ b/src/lib/database/expenses.ts
@@ -1,6 +1,5 @@
 import prisma from "@/lib/prisma";
-import { Expense } from "@/types/expenses.types";
-import { ContributionType } from "@/types/contributions.types";
+import { Expense, ExpenseType } from "@/types/expenses.types";
 import { formatDateForStorage } from "@/lib/utils";
 
 export async function getExpenses(): Promise<Expense[]> {
@@ -12,7 +11,7 @@ export async function getExpenses(): Promise<Expense[]> {
     });
     return expenses.map(expense => ({
       ...expense,
-      type: expense.type as ContributionType,
+      type: "general" as ExpenseType,
       date: formatDateForStorage(expense.date)
     }));
   } catch (error) {
@@ -29,7 +28,7 @@ export async function getExpenseById(id: number): Promise<Expense | null> {
     if (!expense) return null;
     return {
       ...expense,
-      type: expense.type as ContributionType,
+      type: "general" as ExpenseType,
       date: formatDateForStorage(expense.date)
     };
   } catch (error) {
@@ -55,7 +54,7 @@ export async function createExpense(data: {
     });
     return {
       ...expense,
-      type: expense.type as ContributionType,
+      type: "general" as ExpenseType,
       date: formatDateForStorage(expense.date)
     };
   } catch (error) {
@@ -85,7 +84,7 @@ export async function updateExpense(
     });
     return {
       ...expense,
-      type: expense.type as ContributionType,
+      type: "general" as ExpenseType,
       date: formatDateForStorage(expense.date)
     };
   } catch (error) {
@@ -116,7 +115,7 @@ export async function getExpensesByType(type: string): Promise<Expense[]> {
     });
     return expenses.map(expense => ({
       ...expense,
-      type: expense.type as ContributionType,
+      type: "general" as ExpenseType,
       date: formatDateForStorage(expense.date)
     }));
   } catch (error) {
@@ -137,7 +136,7 @@ export async function getExpensesByCategory(
     });
     return expenses.map(expense => ({
       ...expense,
-      type: expense.type as ContributionType,
+      type: "general" as ExpenseType,
       date: formatDateForStorage(expense.date)
     }));
   } catch (error) {

--- a/src/types/expenses.types.ts
+++ b/src/types/expenses.types.ts
@@ -1,8 +1,8 @@
-import { ContributionType } from "./contributions.types";
+export type ExpenseType = "general";
 
 export interface Expense {
   id: number;
-  type: ContributionType;
+  type: ExpenseType;
   amount: number;
   date: string;
   description: string;


### PR DESCRIPTION
## Summary
• Removes expense type selection from forms - all expenses are now unified as "general"
• Removes type filtering from expense dashboard and tables
• Eliminates TypeBadge component from expense display
• Maintains database compatibility by keeping type column with default "general" value

## Test plan
- [ ] Verify expense form no longer shows type selection dropdown
- [ ] Confirm expense table displays without type column
- [ ] Check that expense filtering only shows year filter (no type filter)
- [ ] Test that new expenses are created with "general" type
- [ ] Ensure existing expenses still display properly

🤖 Generated with [Claude Code](https://claude.ai/code)