### PR TITLE
fix: constrain lot filter width on desktop

### DIFF
--- a/src/components/shared/LotCards.tsx
+++ b/src/components/shared/LotCards.tsx
@@ -179,7 +179,7 @@ export default function LotCards({
                   setSortDirection(direction);
                 }}
               >
-                <SelectTrigger className="w-full text-xs sm:text-sm">
+                <SelectTrigger className="w-full sm:w-64 text-xs sm:text-sm">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>


### PR DESCRIPTION
## Summary
• Fixed the lot sorting filter width on desktop screens
• Changed from full width to w-64 (256px) for better visual proportion
• Maintained responsive design with full width on mobile

## Test plan
- [x] Verify filter looks appropriately sized on desktop
- [x] Confirm mobile layout remains unchanged
- [x] Test functionality of sort options

🤖 Generated with [Claude Code](https://claude.ai/code)