### PR TITLE
feat: add detailed contributions breakdown by type in lot cards

### DIFF
--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -103,6 +103,7 @@ export const translations = {
     noData: "Sin datos",
     contributions: "Aportes",
     outstandingBalance: "Saldo Adeudado",
+    totalOutstandingDebt: "Total Deuda",
     sortBy: "Ordenar por",
   },
 


### PR DESCRIPTION
## Summary
Add itemized breakdown of contributions by type (Maintenance, Works, Others) in home page lot cards with improved visual hierarchy and formatting.

## Changes Made
- ✅ Calculate and display contributions by type (maintenance, works, others)
- ✅ Update LotWithSummary interface to include breakdown totals  
- ✅ Relocate initial debt from owner section to values section
- ✅ Replace "Saldo Adeudado" with "Total Deuda" label
- ✅ Change "Total" to "Total Aportes" for better clarity
- ✅ Apply consistent emerald-green color to all contribution amounts
- ✅ Add visual separator line before totals
- ✅ Maintain responsive design for mobile and desktop

## Visual Structure
```
  Mantenimiento: $120,000 (green)
         Obras: $300,000 (green)
─────────────────────────────
 Total Aportes: $470,000 (green bold)
  Deuda Inicial: $500,000 (amber, only if > 0)
   Total Deuda: $80,000 (red/green based on status)
```

## Files Changed
- `src/components/shared/LotCards.tsx` - Main breakdown logic and UI
- `src/lib/translations.ts` - Added `totalOutstandingDebt` translation

## Test Plan
- [x] Verify breakdown shows correct amounts per type
- [x] Check responsive design on mobile and desktop  
- [x] Confirm initial debt only appears when > 0
- [x] Validate color coding and formatting
- [x] ESLint passes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)