### PR TITLE
fix: use environment-aware redirect URI for Google OAuth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Application
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+
 # Database
 POSTGRES_URL=your_postgres_url_here
 PRISMA_DATABASE_URL=your_prisma_database_url_here

--- a/src/lib/services/google-oauth-service.ts
+++ b/src/lib/services/google-oauth-service.ts
@@ -14,11 +14,12 @@ class GoogleOAuthService {
 
   constructor() {
     try {
-      // Initialize OAuth2 client
+      const redirectUri = `${process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000"}/api/auth/google/callback`;
+
       this.oauth2Client = new google.auth.OAuth2(
         process.env.GOOGLE_CLIENT_ID,
         process.env.GOOGLE_CLIENT_SECRET,
-        "http://localhost:3000/api/auth/google/callback" // Redirect URI
+        redirectUri
       );
 
       // Set refresh token for automatic access token renewal


### PR DESCRIPTION
## Summary
Fix Google OAuth redirect URI to work in both development and production environments.

## Problem
The Google OAuth redirect URI was hardcoded to `http://localhost:3000/api/auth/google/callback`, which breaks the OAuth flow when the app is deployed to production (Vercel).

## Solution
- Use `NEXT_PUBLIC_APP_URL` environment variable to dynamically construct the redirect URI
- Fallback to localhost if the environment variable is not set
- Add documentation to `.env.example`

## Changes
- **`.env.example`**: Added `NEXT_PUBLIC_APP_URL` with default localhost value
- **`google-oauth-service.ts`**: Replace hardcoded redirect URI with dynamic one based on environment

## Setup Required

### Local Development
Add to `.env.local`:
```env
NEXT_PUBLIC_APP_URL=http://localhost:3000
```

### Production (Vercel)
Add environment variable in Vercel dashboard:
```
NEXT_PUBLIC_APP_URL=https://your-production-domain.vercel.app
```

### Google Cloud Console
Add the production redirect URI to authorized redirect URIs:
```
https://your-production-domain.vercel.app/api/auth/google/callback
```
Keep the localhost URI for development.

## Test Plan
- [ ] Test OAuth flow in local development
- [ ] Test OAuth flow in production after deploying
- [ ] Verify redirect URI is correctly constructed in both environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)