### PR TITLE
fix: compact WhatsApp message, fix date icon, add saldo total de caja

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -39,7 +39,7 @@ export default async function Home() {
           <QuotaSummaryCard lotBalances={lotBalances} />
           {userRole === "admin" && (
             <div className="flex justify-end">
-              <WhatsAppReportButton lotBalances={lotBalances} />
+              <WhatsAppReportButton lotBalances={lotBalances} consolidatedBalance={fundsData.consolidated.balance} />
             </div>
           )}
           <LotCards

--- a/src/components/shared/ItemCard.tsx
+++ b/src/components/shared/ItemCard.tsx
@@ -1,4 +1,4 @@
-import { Edit, Trash2, Calendar, Receipt, Eye, FileText } from "lucide-react";
+import { Edit, Trash2, Receipt, Eye, FileText } from "lucide-react";
 import { Button } from "@/components/ui/Button";
 import { formatCurrency, formatDateForDisplay } from "@/lib/utils";
 import { translations } from "@/lib/translations";
@@ -62,7 +62,6 @@ export default function ItemCard({
       {/* Header Row - Date */}
       <div className="mb-3 pr-24">
         <div className="flex items-center gap-2 text-gray-500">
-          <Calendar className="h-4 w-4" />
           <time className="text-sm font-medium">
             {formatDateForDisplay(date)}
           </time>

--- a/src/components/shared/WhatsAppReportButton.tsx
+++ b/src/components/shared/WhatsAppReportButton.tsx
@@ -9,12 +9,11 @@ import { translations } from "@/lib/translations";
 
 const t = translations.whatsapp;
 
-function generateWhatsAppReport(lotBalances: SimpleLotBalance[]): string {
+function generateWhatsAppReport(lotBalances: SimpleLotBalance[], consolidatedBalance: number): string {
   const today = formatDateForDisplay(new Date());
   const lines: string[] = [];
 
-  lines.push(t.reportTitle);
-  lines.push(`${t.reportDate} ${today}`);
+  lines.push(`${t.reportTitle} — ${today}`);
   lines.push(t.reportSeparator);
   lines.push(t.reportLots);
 
@@ -23,26 +22,21 @@ function generateWhatsAppReport(lotBalances: SimpleLotBalance[]): string {
   );
 
   for (const lot of sorted) {
-    lines.push("");
-    lines.push(`${t.lotPrefix} ${lot.lotNumber}* — ${t.ownerPrefix} ${lot.owner}`);
-    if (lot.outstandingBalance === 0) {
-      lines.push(t.currentLabel);
-    } else {
-      lines.push(`${t.owedLabel} ${formatCurrency(lot.outstandingBalance)}`);
-    }
+    const status = lot.outstandingBalance === 0
+      ? t.currentLabel
+      : `${t.owedLabel} ${formatCurrency(lot.outstandingBalance)}`;
+    lines.push(`${t.lotPrefix} ${lot.lotNumber}* ${t.ownerPrefix} ${lot.owner} · ${status}`);
   }
 
   const overdueCount = lotBalances.filter((l) => l.status === "overdue").length;
   const currentCount = lotBalances.filter((l) => l.status === "current").length;
   const totalDebt = lotBalances.reduce((sum, l) => sum + l.outstandingBalance, 0);
 
-  lines.push("");
   lines.push(t.reportSeparator);
   lines.push(t.summaryTitle);
-  lines.push(`${t.summaryTotalLots} ${lotBalances.length}`);
-  lines.push(`${t.summaryOverdue} ${overdueCount}`);
-  lines.push(`✅ Al día: ${currentCount}`);
+  lines.push(`${t.summaryTotalLots} ${lotBalances.length} · ${t.summaryOverdue} ${overdueCount} · ✅ ${currentCount}`);
   lines.push(`${t.summaryDebt} ${formatCurrency(totalDebt)}`);
+  lines.push(`${t.summaryCashBalance} ${formatCurrency(consolidatedBalance)}`);
   lines.push(t.reportSeparator);
   lines.push(t.summaryFooter);
 
@@ -53,14 +47,15 @@ type CopyStatus = "idle" | "copied" | "error";
 
 interface WhatsAppReportButtonProps {
   lotBalances: SimpleLotBalance[];
+  consolidatedBalance: number;
 }
 
-export default function WhatsAppReportButton({ lotBalances }: WhatsAppReportButtonProps) {
+export default function WhatsAppReportButton({ lotBalances, consolidatedBalance }: WhatsAppReportButtonProps) {
   const [status, setStatus] = useState<CopyStatus>("idle");
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   async function handleClick() {
-    const text = generateWhatsAppReport(lotBalances);
+    const text = generateWhatsAppReport(lotBalances, consolidatedBalance);
     try {
       await navigator.clipboard.writeText(text);
       if (timeoutRef.current) clearTimeout(timeoutRef.current);

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -443,6 +443,7 @@ export const translations = {
     summaryTotalLots: "Total lotes:",
     summaryOverdue: "En mora:",
     summaryDebt: "Cartera total:",
+    summaryCashBalance: "💰 Saldo de caja:",
     summaryFooter: "_Generado desde Parcela Jaslico_",
   },
 


### PR DESCRIPTION
- Remove Lucide Calendar icon from ItemCard (its SVG always shows 'FEB 24',
  which was confusing next to the actual formatted date text)
- Make WhatsApp report more compact: merge title and date into one line,
  show each lot on a single line (no blank lines between lots), and
  consolidate summary counts into one line
- Add consolidated cash balance (saldo de caja) at the end of the report
- Pass fundsData.consolidated.balance from page.tsx to WhatsAppReportButton
- Add summaryCashBalance translation key

https://claude.ai/code/session_01M7RdwXF2ZHd3qdQJkct5MN