### PR TITLE
fix: restore blank lines between lots in WhatsApp report

### DIFF
--- a/src/components/shared/WhatsAppReportButton.tsx
+++ b/src/components/shared/WhatsAppReportButton.tsx
@@ -22,10 +22,13 @@ function generateWhatsAppReport(lotBalances: SimpleLotBalance[], consolidatedBal
   );
 
   for (const lot of sorted) {
-    const status = lot.outstandingBalance === 0
-      ? t.currentLabel
-      : `${t.owedLabel} ${formatCurrency(lot.outstandingBalance)}`;
-    lines.push(`${t.lotPrefix} ${lot.lotNumber}* ${t.ownerPrefix} ${lot.owner} · ${status}`);
+    lines.push("");
+    lines.push(`${t.lotPrefix} ${lot.lotNumber}* — ${t.ownerPrefix} ${lot.owner}`);
+    if (lot.outstandingBalance === 0) {
+      lines.push(t.currentLabel);
+    } else {
+      lines.push(`${t.owedLabel} ${formatCurrency(lot.outstandingBalance)}`);
+    }
   }
 
   const overdueCount = lotBalances.filter((l) => l.status === "overdue").length;


### PR DESCRIPTION
Compact single-line format was hard to read with many lots. Restore one blank line before each lot entry for clarity.

https://claude.ai/code/session_01M7RdwXF2ZHd3qdQJkct5MN