### PR TITLE
Add loading spinner to expense modal submit button

### DIFF
--- a/src/components/modals/ExpenseModal.tsx
+++ b/src/components/modals/ExpenseModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useActionState, useTransition, useState } from "react";
+import { Loader2 } from "lucide-react";
 import { useReceiptUpload } from "@/hooks/useReceiptUpload";
 import { Expense } from "@/types/expenses.types";
 import {
@@ -37,12 +38,13 @@ export default function ExpenseModal({
   const action = expense ? updateExpenseAction : createExpenseAction;
   const [state, formAction] = useActionState(action, initialState);
   const [isPending, startTransition] = useTransition();
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [previewFileName, setPreviewFileName] = useState<string | undefined>(
     expense?.receiptFileName || undefined
   );
   const { uploadReceipt, isUploading } = useReceiptUpload();
-  const isLoading = isUploading || isPending;
+  const isLoading = isUploading || isPending || isSubmitting;
 
   useEffect(() => {
     if (state?.success) {
@@ -51,6 +53,7 @@ export default function ExpenseModal({
   }, [state, onClose]);
 
   const handleSubmit = async (formData: FormData) => {
+    setIsSubmitting(true);
     try {
       if (selectedFile || (expense && expense.receiptFileId)) {
         await uploadReceipt({
@@ -76,6 +79,7 @@ export default function ExpenseModal({
         formAction(formData);
       });
     } catch (error) {
+      setIsSubmitting(false);
       const errorInstance =
         error instanceof Error ? error : new Error(String(error));
       alert(`Error: ${errorInstance.message}`);
@@ -225,14 +229,18 @@ export default function ExpenseModal({
           <Button
             type="submit"
             form="expense-form"
-            variant="secondary"
             disabled={isLoading}
           >
-            {isLoading
-              ? translations.status.processing
-              : expense
-                ? translations.actions.update
-                : translations.actions.save}
+            {isLoading ? (
+              <>
+                <Loader2 className="animate-spin" />
+                {translations.status.processing}
+              </>
+            ) : expense ? (
+              translations.actions.update
+            ) : (
+              translations.actions.save
+            )}
           </Button>
         </DialogFooter>
       </DialogContent>


### PR DESCRIPTION
## Summary
Enhanced the expense modal's submit button with a visual loading indicator and improved loading state management during form submission.

## Key Changes
- Added `Loader2` icon import from lucide-react for the loading spinner animation
- Introduced `isSubmitting` state to track the form submission lifecycle independently
- Updated `isLoading` computed state to include the new `isSubmitting` flag alongside existing `isUploading` and `isPending` states
- Enhanced submit button UI to display an animated spinner icon alongside the "Processing" text when loading
- Removed the `variant="secondary"` styling from the submit button for a more prominent default appearance
- Set `isSubmitting` to `false` in the error catch block to ensure proper state cleanup on submission failures

## Implementation Details
- The `isSubmitting` state is set to `true` at the start of `handleSubmit` and reset to `false` only on error, allowing the `isPending` state from `useActionState` to handle the final state reset on success
- The loading spinner uses Tailwind's `animate-spin` class for smooth continuous rotation
- The button remains disabled during all loading phases (upload, submission, or transition)

https://claude.ai/code/session_01Xs8pMpcFXMpJ9pyj1sHAhY