### PR TITLE
fix: change expense Save button variant to primary

### DIFF
--- a/src/components/modals/ExpenseModal.tsx
+++ b/src/components/modals/ExpenseModal.tsx
@@ -225,7 +225,6 @@ export default function ExpenseModal({
           <Button
             type="submit"
             form="expense-form"
-            variant="secondary"
             disabled={isLoading}
           >
             {isLoading


### PR DESCRIPTION
Fix Save button in expense modal to use primary (default) variant instead of secondary.

Closes #67

Generated with [Claude Code](https://claude.ai/code)