### PR TITLE
feat: use NEXTAUTH_URL as redirectProxyUrl for Vercel preview deployments

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -31,6 +31,13 @@ const productionUrl = process.env.NEXTAUTH_URL?.replace(/\/$/, "");
 const redirectProxyUrl =
   isPreview && productionUrl ? `${productionUrl}/api/auth` : undefined;
 
+// For preview deployments, tell Auth.js its own URL so it correctly
+// encodes the preview URL in the OAuth state parameter.
+// Production reads this state and redirects back to the preview URL.
+if (isPreview && process.env.VERCEL_URL && !process.env.AUTH_URL) {
+  process.env.AUTH_URL = `https://${process.env.VERCEL_URL}`;
+}
+
 export const authConfig: NextAuthConfig = {
   ...(redirectProxyUrl && { redirectProxyUrl }),
   providers: [

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -26,7 +26,13 @@ declare module "@auth/core/jwt" {
 const ADMIN_EMAILS =
   process.env.ADMIN_EMAILS?.split(",").map((email) => email.trim()) || [];
 
+const isPreview = process.env.VERCEL_ENV === "preview";
+const productionUrl = process.env.NEXTAUTH_URL?.replace(/\/$/, "");
+const redirectProxyUrl =
+  isPreview && productionUrl ? `${productionUrl}/api/auth` : undefined;
+
 export const authConfig: NextAuthConfig = {
+  ...(redirectProxyUrl && { redirectProxyUrl }),
   providers: [
     Google({
       clientId: process.env.GOOGLE_CLIENT_ID!,

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -28,8 +28,11 @@ const ADMIN_EMAILS =
 
 const isPreview = process.env.VERCEL_ENV === "preview";
 const productionUrl = process.env.NEXTAUTH_URL?.replace(/\/$/, "");
-const redirectProxyUrl =
-  isPreview && productionUrl ? `${productionUrl}/api/auth` : undefined;
+
+// Set redirectProxyUrl on BOTH preview and production:
+// - Preview: routes OAuth callbacks through production (Google's redirect_uri points to production)
+// - Production: enables Auth.js to relay callbacks back to preview deployments
+const redirectProxyUrl = productionUrl ? `${productionUrl}/api/auth` : undefined;
 
 // For preview deployments, tell Auth.js its own URL so it correctly
 // encodes the preview URL in the OAuth state parameter.


### PR DESCRIPTION
Detects Vercel preview environments via VERCEL_ENV and automatically configures Auth.js redirectProxyUrl using the production NEXTAUTH_URL, so OAuth flows work on dynamic preview URLs without registering each preview URL in Google Console.

Closes #69

Generated with [Claude Code](https://claude.ai/code)