### PR TITLE
feat: use NEXTAUTH_URL as redirectProxyUrl for Vercel preview deployments

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -26,10 +26,13 @@ declare module "@auth/core/jwt" {
 const ADMIN_EMAILS =
   process.env.ADMIN_EMAILS?.split(",").map((email) => email.trim()) || [];
 
-const isPreview = process.env.VERCEL_ENV === "preview";
+// Set redirectProxyUrl in ALL environments so that production can proxy
+// OAuth callbacks back to preview deployments (Auth.js v5 requirement).
+// See: https://authjs.dev/getting-started/deployment#securing-a-preview-deployment
 const productionUrl = process.env.NEXTAUTH_URL?.replace(/\/$/, "");
-const redirectProxyUrl =
-  isPreview && productionUrl ? `${productionUrl}/api/auth` : undefined;
+const redirectProxyUrl = productionUrl
+  ? `${productionUrl}/api/auth`
+  : undefined;
 
 export const authConfig: NextAuthConfig = {
   ...(redirectProxyUrl && { redirectProxyUrl }),

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -29,7 +29,13 @@ const ADMIN_EMAILS =
 // Set redirectProxyUrl in ALL environments so that production can proxy
 // OAuth callbacks back to preview deployments (Auth.js v5 requirement).
 // See: https://authjs.dev/getting-started/deployment#securing-a-preview-deployment
-const productionUrl = process.env.NEXTAUTH_URL?.replace(/\/$/, "");
+//
+// VERCEL_PROJECT_PRODUCTION_URL is a Vercel system env var (no https:// prefix)
+// automatically available in all environments (production, preview, development).
+// Falls back to NEXTAUTH_URL for non-Vercel environments.
+const productionUrl = process.env.VERCEL_PROJECT_PRODUCTION_URL
+  ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
+  : process.env.NEXTAUTH_URL?.replace(/\/$/, "");
 const redirectProxyUrl = productionUrl
   ? `${productionUrl}/api/auth`
   : undefined;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -26,16 +26,12 @@ declare module "@auth/core/jwt" {
 const ADMIN_EMAILS =
   process.env.ADMIN_EMAILS?.split(",").map((email) => email.trim()) || [];
 
-// Set redirectProxyUrl in ALL environments so that production can proxy
-// OAuth callbacks back to preview deployments (Auth.js v5 requirement).
+// Set redirectProxyUrl in ALL environments (production and preview) so that
+// production can proxy OAuth callbacks back to the preview deployment URL.
+// Auth.js encodes the current deployment URL (preview) in the OAuth state,
+// so production knows where to redirect back after the callback.
 // See: https://authjs.dev/getting-started/deployment#securing-a-preview-deployment
-//
-// VERCEL_PROJECT_PRODUCTION_URL is a Vercel system env var (no https:// prefix)
-// automatically available in all environments (production, preview, development).
-// Falls back to NEXTAUTH_URL for non-Vercel environments.
-const productionUrl = process.env.VERCEL_PROJECT_PRODUCTION_URL
-  ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
-  : process.env.NEXTAUTH_URL?.replace(/\/$/, "");
+const productionUrl = process.env.NEXTAUTH_URL?.replace(/\/$/, "");
 const redirectProxyUrl = productionUrl
   ? `${productionUrl}/api/auth`
   : undefined;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -26,7 +26,13 @@ declare module "@auth/core/jwt" {
 const ADMIN_EMAILS =
   process.env.ADMIN_EMAILS?.split(",").map((email) => email.trim()) || [];
 
+const isPreview = process.env.VERCEL_ENV === "preview";
+const productionUrl = process.env.NEXTAUTH_URL?.replace(/\/$/, "");
+const redirectProxyUrl =
+  isPreview && productionUrl ? `${productionUrl}/api/auth` : undefined;
+
 export const authConfig: NextAuthConfig = {
+  ...(redirectProxyUrl && { redirectProxyUrl }),
   providers: [
     Google({
       clientId: process.env.GOOGLE_CLIENT_ID!,


### PR DESCRIPTION
Detects Vercel preview environments via VERCEL_ENV and automatically
configures Auth.js redirectProxyUrl using the production NEXTAUTH_URL,
so OAuth flows work on dynamic preview URLs without registering each
preview URL in Google Console.

Co-authored-by: Alejandro Martinez <alejomartinez8@users.noreply.github.com>