### PR TITLE
Prevent duplicate expense submissions with ref-based guard

### DIFF
--- a/src/components/modals/ExpenseModal.tsx
+++ b/src/components/modals/ExpenseModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useActionState, useTransition, useState } from "react";
+import { useEffect, useActionState, useTransition, useState, useRef } from "react";
 import { Loader2 } from "lucide-react";
 import { useReceiptUpload } from "@/hooks/useReceiptUpload";
 import { Expense } from "@/types/expenses.types";
@@ -39,6 +39,7 @@ export default function ExpenseModal({
   const [state, formAction] = useActionState(action, initialState);
   const [isPending, startTransition] = useTransition();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const submittingRef = useRef(false);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [previewFileName, setPreviewFileName] = useState<string | undefined>(
     expense?.receiptFileName || undefined
@@ -53,6 +54,8 @@ export default function ExpenseModal({
   }, [state, onClose]);
 
   const handleSubmit = async (formData: FormData) => {
+    if (submittingRef.current) return;
+    submittingRef.current = true;
     setIsSubmitting(true);
     try {
       if (selectedFile || (expense && expense.receiptFileId)) {
@@ -79,6 +82,7 @@ export default function ExpenseModal({
         formAction(formData);
       });
     } catch (error) {
+      submittingRef.current = false;
       setIsSubmitting(false);
       const errorInstance =
         error instanceof Error ? error : new Error(String(error));


### PR DESCRIPTION
## Summary

Added a ref-based guard mechanism to prevent duplicate expense form submissions when the submit button is clicked multiple times rapidly.

## Key Changes

- Added `useRef` import to track submission state across renders
- Introduced `submittingRef` to maintain submission state that persists across re-renders
- Added early return in `handleSubmit` if a submission is already in progress
- Reset the ref flag in the error catch block to allow retries after failures

## Implementation Details

The solution uses a `useRef` to track submission state (`submittingRef.current`) which is checked at the start of `handleSubmit`. This prevents the async submission logic from executing multiple times even if the form is submitted rapidly. The ref is reset to `false` in the error handler to allow users to retry after a failed submission, while the existing `isSubmitting` state continues to manage UI feedback (loading states, button disabling, etc.).

This approach is more reliable than relying solely on state updates for preventing duplicate submissions, as refs maintain their value across renders without triggering re-renders themselves.

https://claude.ai/code/session_013PR8oEFXYAiPhUbhadc4yg