### PR TITLE
Fix chart: red expenses line and Spanish labels in tooltip

### DIFF
--- a/src/components/shared/FinancialChart.tsx
+++ b/src/components/shared/FinancialChart.tsx
@@ -46,7 +46,7 @@ function CustomTooltip({
       </p>
       {payload.map((p) => (
         <p key={p.name} style={{ color: p.color }}>
-          {p.name}:{" "}
+          {p.name === "income" ? translations.labels.income : translations.labels.expenses}:{" "}
           <span className="font-semibold">
             {new Intl.NumberFormat("es-CO", {
               style: "currency",
@@ -112,9 +112,9 @@ export default function FinancialChart({ data }: FinancialChartProps) {
         <Line
           type="monotone"
           dataKey="expenses"
-          stroke="#6b7280"
+          stroke="#dc2626"
           strokeWidth={2}
-          dot={{ r: 3, fill: "#6b7280" }}
+          dot={{ r: 3, fill: "#dc2626" }}
           activeDot={{ r: 5 }}
         />
       </LineChart>


### PR DESCRIPTION
## Summary

- Expenses line color changed from gray to red (`#dc2626`) for clearer visual contrast with income
- Tooltip now shows "Aportes" / "Gastos" instead of the raw `income` / `expenses` datakeys

## Test plan

- [ ] Open dashboard and verify the chart shows a red line for expenses
- [ ] Hover over chart points and verify tooltip labels are in Spanish

https://claude.ai/code/session_01AYZ74BCWpmnzSuPHjxFfrj

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYZ74BCWpmnzSuPHjxFfrj)_