### PR TITLE
Filter out zero-balance lots from WhatsApp report

### DIFF
--- a/src/components/shared/WhatsAppReportButton.tsx
+++ b/src/components/shared/WhatsAppReportButton.tsx
@@ -21,7 +21,9 @@ function generateWhatsAppReport(lotBalances: SimpleLotBalance[], consolidatedBal
     a.lotNumber.localeCompare(b.lotNumber, undefined, { numeric: true })
   );
 
-  for (const lot of sorted) {
+  const debtors = sorted.filter((l) => l.outstandingBalance > 0);
+
+  for (const lot of debtors) {
     lines.push("");
     lines.push(`${t.lotPrefix} ${lot.lotNumber}* — ${t.ownerPrefix} ${lot.owner}`);
     if (lot.outstandingBalance === 0) {


### PR DESCRIPTION
## Summary

Modified the WhatsApp report generation to exclude lots with zero outstanding balance, improving report clarity by focusing only on debtors.

## Key Changes

- Added filtering logic to `generateWhatsAppReport()` to create a `debtors` array containing only lots with `outstandingBalance > 0`
- Updated the report loop to iterate over `debtors` instead of all sorted lots
- This ensures the WhatsApp message only includes lots with actual outstanding balances

## Implementation Details

The change filters the sorted lot list before the report generation loop, reducing unnecessary entries in the generated message and making the report more concise and actionable for users tracking outstanding debts.

https://claude.ai/code/session_0139NsgQxyBcTg2c61a4bDpD