### PR TITLE
Add WhatsApp lot report generation with quota breakdown

### DIFF
--- a/src/app/income/[id]/page.tsx
+++ b/src/app/income/[id]/page.tsx
@@ -49,6 +49,7 @@ export default async function LotPage({ params }: LotPageProps) {
         allLots={allLotsData}
         isAdmin={userRole === "admin"}
         debtDetail={debtDetail}
+        quotaConfigs={quotaConfigs}
       />
     );
   } catch (error) {

--- a/src/components/shared/LotDetailView.tsx
+++ b/src/components/shared/LotDetailView.tsx
@@ -28,6 +28,7 @@ import {
   SelectValue,
 } from "@/components/ui/Select";
 import TypeBadge from "@/components/shared/TypeBadge";
+import WhatsAppLotReportButton from "@/components/shared/WhatsAppLotReportButton";
 import ContributionModal from "@/components/modals/ContributionModal";
 import ConfirmationModal from "@/components/modals/ConfirmationModal";
 import { deleteContributionAction } from "@/lib/actions/contribution-actions";
@@ -215,6 +216,15 @@ export default function LotDetailView({
               </h1>
               <p className="text-muted-foreground mt-1 text-lg">{lot.owner}</p>
             </div>
+            {debtDetail && (
+              <WhatsAppLotReportButton
+                lotNumber={lot.lotNumber}
+                owner={lot.owner}
+                debtDetail={debtDetail}
+                maintenancePaid={fundTotals.maintenance}
+                worksPaid={fundTotals.works}
+              />
+            )}
           </div>
 
           {/* Lot Selector Section - Only for admins */}

--- a/src/components/shared/LotDetailView.tsx
+++ b/src/components/shared/LotDetailView.tsx
@@ -16,6 +16,8 @@ import {
   formatCurrency,
   formatDateForDisplay,
   getStatusColor,
+  buildQuotaBreakdown,
+  QuotaLineStatus,
 } from "@/lib/utils";
 import { LotDebtDetail } from "@/types/quotas.types";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/Card";
@@ -43,12 +45,21 @@ import {
   TableRow,
 } from "@/components/ui/Table";
 
+interface QuotaConfig {
+  id: string;
+  quotaType: string;
+  amount: number;
+  description: string | null;
+  dueDate: Date | null;
+}
+
 interface LotDetailViewProps {
   lot: Lot & { contributions: Contribution[] };
   contributions: Contribution[];
   allLots: Lot[];
   isAdmin?: boolean;
   debtDetail?: LotDebtDetail | null;
+  quotaConfigs?: QuotaConfig[];
 }
 
 type SortField = "date" | "description" | "type" | "amount" | "receiptNumber";
@@ -60,6 +71,7 @@ export default function LotDetailView({
   allLots,
   isAdmin = false,
   debtDetail,
+  quotaConfigs = [],
 }: LotDetailViewProps) {
   const [editingContribution, setEditingContribution] =
     useState<Contribution | null>(null);
@@ -152,6 +164,11 @@ export default function LotDetailView({
     };
   }, [contributions, debtDetail]);
 
+  const quotaBreakdown = useMemo<QuotaLineStatus[]>(() => {
+    if (!quotaConfigs.length) return [];
+    return buildQuotaBreakdown(quotaConfigs, contributions, lot);
+  }, [quotaConfigs, contributions, lot]);
+
   const handleSort = (field: SortField) => {
     if (sortField === field) {
       setSortDirection(sortDirection === "asc" ? "desc" : "asc");
@@ -221,8 +238,7 @@ export default function LotDetailView({
                 lotNumber={lot.lotNumber}
                 owner={lot.owner}
                 debtDetail={debtDetail}
-                maintenancePaid={fundTotals.maintenance}
-                worksPaid={fundTotals.works}
+                quotaBreakdown={quotaBreakdown}
               />
             )}
           </div>
@@ -389,6 +405,72 @@ export default function LotDetailView({
               </CardContent>
             </Card>
           </div>
+        )}
+
+        {/* Quota Breakdown Table */}
+        {quotaBreakdown.length > 0 && (
+          <Card className="shadow-sm">
+            <CardHeader>
+              <CardTitle>{translations.titles.quotaBreakdown}</CardTitle>
+            </CardHeader>
+            <CardContent className="p-0">
+              <div className="overflow-hidden rounded-md border-0">
+                <Table className="border-separate border-spacing-0">
+                  <TableHeader>
+                    <TableRow className="bg-muted/50 hover:bg-muted/50">
+                      <TableHead className="border-border border-b-2 px-6 py-4 font-semibold tracking-wide">
+                        {translations.labels.description}
+                      </TableHead>
+                      <TableHead className="border-border border-b-2 px-6 py-4 font-semibold tracking-wide">
+                        {translations.labels.type}
+                      </TableHead>
+                      <TableHead className="border-border border-b-2 px-6 py-4 text-right font-semibold tracking-wide">
+                        {translations.labels.amount}
+                      </TableHead>
+                      <TableHead className="border-border border-b-2 px-6 py-4 font-semibold tracking-wide">
+                        {translations.labels.status}
+                      </TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {quotaBreakdown.map((line, index) => (
+                      <TableRow
+                        key={line.id + index}
+                        className={`border-border/50 border-b transition-all duration-200 ${
+                          index % 2 === 0 ? "bg-background" : "bg-muted/20"
+                        }`}
+                      >
+                        <TableCell className="px-6 py-3 font-medium">{line.label}</TableCell>
+                        <TableCell className="px-6 py-3">
+                          <TypeBadge type={line.quotaType === "initial" ? "works" : line.quotaType as "maintenance" | "works"} />
+                        </TableCell>
+                        <TableCell className="px-6 py-3 text-right font-semibold">
+                          {formatCurrency(line.amount)}
+                        </TableCell>
+                        <TableCell className="px-6 py-3">
+                          {line.status === "paid" && (
+                            <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-1 text-xs font-semibold text-green-800">
+                              ✅ {translations.labels.paid}
+                            </span>
+                          )}
+                          {line.status === "partial" && (
+                            <span className="inline-flex flex-col rounded-full bg-yellow-100 px-2 py-1 text-xs font-semibold text-yellow-800">
+                              ⚠️ Parcial ({formatCurrency(line.paidAmount)} / {formatCurrency(line.amount)})
+                            </span>
+                          )}
+                          {line.status === "owed" && (
+                            <span className="inline-flex items-center gap-1 rounded-full bg-red-100 px-2 py-1 text-xs font-semibold text-red-800">
+                              🔴 {translations.labels.owes}
+                            </span>
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            </CardContent>
+          </Card>
         )}
 
         {/* Payments Table */}

--- a/src/components/shared/WhatsAppLotReportButton.tsx
+++ b/src/components/shared/WhatsAppLotReportButton.tsx
@@ -4,7 +4,7 @@ import { useRef, useState } from "react";
 import { MessageSquare } from "lucide-react";
 import { Button } from "@/components/ui/Button";
 import { LotDebtDetail } from "@/types/quotas.types";
-import { formatCurrency, formatDateForDisplay } from "@/lib/utils";
+import { QuotaLineStatus, formatCurrency, formatDateForDisplay } from "@/lib/utils";
 import { translations } from "@/lib/translations";
 
 const t = translations.whatsapp;
@@ -13,42 +13,56 @@ interface WhatsAppLotReportButtonProps {
   lotNumber: string;
   owner: string;
   debtDetail: LotDebtDetail;
-  maintenancePaid: number;
-  worksPaid: number;
+  quotaBreakdown: QuotaLineStatus[];
 }
 
 function generateLotReport(
   lotNumber: string,
   owner: string,
   debtDetail: LotDebtDetail,
-  maintenancePaid: number,
-  worksPaid: number
+  quotaBreakdown: QuotaLineStatus[]
 ): string {
   const today = formatDateForDisplay(new Date());
   const lines: string[] = [];
 
-  const maintenanceTotalQuota = maintenancePaid + debtDetail.maintenanceDebt;
-  const worksTotalQuota = worksPaid + debtDetail.worksDebt;
-
-  lines.push(`${t.lotReportTitle}`);
+  lines.push(t.lotReportTitle);
   lines.push(`${t.lotReportLotPrefix} ${lotNumber}* — ${owner}`);
   lines.push(t.reportSeparator);
 
-  if (debtDetail.initialWorksDebt > 0) {
-    lines.push(`${t.lotReportInitialBalance} ${formatCurrency(debtDetail.initialWorksDebt)}`);
+  const maintenanceLines = quotaBreakdown.filter((q) => q.quotaType === "maintenance");
+  const worksLines = quotaBreakdown.filter((q) => q.quotaType === "works" || q.quotaType === "initial");
+
+  if (maintenanceLines.length > 0) {
+    lines.push(t.lotReportMaintenance);
+    for (const q of maintenanceLines) {
+      const icon =
+        q.status === "paid" ? t.lotReportQuotaPaid :
+        q.status === "partial" ? t.lotReportQuotaPartial :
+        t.lotReportQuotaOwed;
+      const suffix =
+        q.status === "partial"
+          ? ` (${formatCurrency(q.paidAmount)} / ${formatCurrency(q.amount)})`
+          : ` — ${formatCurrency(q.amount)}`;
+      lines.push(`  ${icon} ${q.label}${suffix}`);
+    }
     lines.push("");
   }
 
-  lines.push(t.lotReportMaintenance);
-  lines.push(`${t.lotReportTotalQuota} ${formatCurrency(maintenanceTotalQuota)}`);
-  lines.push(`${t.lotReportPaid} ${formatCurrency(maintenancePaid)}`);
-  lines.push(`${t.lotReportOwed} ${formatCurrency(debtDetail.maintenanceDebt)}`);
-  lines.push("");
-
-  lines.push(t.lotReportWorks);
-  lines.push(`${t.lotReportTotalQuota} ${formatCurrency(worksTotalQuota)}`);
-  lines.push(`${t.lotReportPaid} ${formatCurrency(worksPaid)}`);
-  lines.push(`${t.lotReportOwed} ${formatCurrency(debtDetail.worksDebt)}`);
+  if (worksLines.length > 0) {
+    lines.push(t.lotReportWorks);
+    for (const q of worksLines) {
+      const icon =
+        q.status === "paid" ? t.lotReportQuotaPaid :
+        q.status === "partial" ? t.lotReportQuotaPartial :
+        t.lotReportQuotaOwed;
+      const suffix =
+        q.status === "partial"
+          ? ` (${formatCurrency(q.paidAmount)} / ${formatCurrency(q.amount)})`
+          : ` — ${formatCurrency(q.amount)}`;
+      lines.push(`  ${icon} ${q.label}${suffix}`);
+    }
+    lines.push("");
+  }
 
   lines.push(t.reportSeparator);
 
@@ -70,14 +84,13 @@ export default function WhatsAppLotReportButton({
   lotNumber,
   owner,
   debtDetail,
-  maintenancePaid,
-  worksPaid,
+  quotaBreakdown,
 }: WhatsAppLotReportButtonProps) {
   const [status, setStatus] = useState<CopyStatus>("idle");
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   async function handleClick() {
-    const text = generateLotReport(lotNumber, owner, debtDetail, maintenancePaid, worksPaid);
+    const text = generateLotReport(lotNumber, owner, debtDetail, quotaBreakdown);
     try {
       await navigator.clipboard.writeText(text);
       if (timeoutRef.current) clearTimeout(timeoutRef.current);

--- a/src/components/shared/WhatsAppLotReportButton.tsx
+++ b/src/components/shared/WhatsAppLotReportButton.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { MessageSquare } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { LotDebtDetail } from "@/types/quotas.types";
+import { formatCurrency, formatDateForDisplay } from "@/lib/utils";
+import { translations } from "@/lib/translations";
+
+const t = translations.whatsapp;
+
+interface WhatsAppLotReportButtonProps {
+  lotNumber: string;
+  owner: string;
+  debtDetail: LotDebtDetail;
+  maintenancePaid: number;
+  worksPaid: number;
+}
+
+function generateLotReport(
+  lotNumber: string,
+  owner: string,
+  debtDetail: LotDebtDetail,
+  maintenancePaid: number,
+  worksPaid: number
+): string {
+  const today = formatDateForDisplay(new Date());
+  const lines: string[] = [];
+
+  const maintenanceTotalQuota = maintenancePaid + debtDetail.maintenanceDebt;
+  const worksTotalQuota = worksPaid + debtDetail.worksDebt;
+
+  lines.push(`${t.lotReportTitle}`);
+  lines.push(`${t.lotReportLotPrefix} ${lotNumber}* — ${owner}`);
+  lines.push(t.reportSeparator);
+
+  if (debtDetail.initialWorksDebt > 0) {
+    lines.push(`${t.lotReportInitialBalance} ${formatCurrency(debtDetail.initialWorksDebt)}`);
+    lines.push("");
+  }
+
+  lines.push(t.lotReportMaintenance);
+  lines.push(`${t.lotReportTotalQuota} ${formatCurrency(maintenanceTotalQuota)}`);
+  lines.push(`${t.lotReportPaid} ${formatCurrency(maintenancePaid)}`);
+  lines.push(`${t.lotReportOwed} ${formatCurrency(debtDetail.maintenanceDebt)}`);
+  lines.push("");
+
+  lines.push(t.lotReportWorks);
+  lines.push(`${t.lotReportTotalQuota} ${formatCurrency(worksTotalQuota)}`);
+  lines.push(`${t.lotReportPaid} ${formatCurrency(worksPaid)}`);
+  lines.push(`${t.lotReportOwed} ${formatCurrency(debtDetail.worksDebt)}`);
+
+  lines.push(t.reportSeparator);
+
+  if (debtDetail.outstandingBalance > 0) {
+    lines.push(`${t.lotReportTotalOwed} ${formatCurrency(debtDetail.outstandingBalance)}`);
+  } else {
+    lines.push(t.lotReportCurrentStatus);
+  }
+
+  lines.push(`${t.lotReportDate} ${today}`);
+  lines.push(t.summaryFooter);
+
+  return lines.join("\n");
+}
+
+type CopyStatus = "idle" | "copied" | "error";
+
+export default function WhatsAppLotReportButton({
+  lotNumber,
+  owner,
+  debtDetail,
+  maintenancePaid,
+  worksPaid,
+}: WhatsAppLotReportButtonProps) {
+  const [status, setStatus] = useState<CopyStatus>("idle");
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  async function handleClick() {
+    const text = generateLotReport(lotNumber, owner, debtDetail, maintenancePaid, worksPaid);
+    try {
+      await navigator.clipboard.writeText(text);
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      setStatus("copied");
+      timeoutRef.current = setTimeout(() => setStatus("idle"), 2000);
+    } catch {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      setStatus("error");
+      timeoutRef.current = setTimeout(() => setStatus("idle"), 2000);
+    }
+  }
+
+  const label =
+    status === "copied"
+      ? t.copied
+      : status === "error"
+        ? t.copyError
+        : t.lotReportCopy;
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={handleClick}
+      className={
+        status === "copied"
+          ? "border-green-500 text-green-600"
+          : status === "error"
+            ? "border-red-500 text-red-600"
+            : ""
+      }
+    >
+      <MessageSquare className="mr-2 h-4 w-4" />
+      {label}
+    </Button>
+  );
+}

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -449,6 +449,19 @@ export const translations = {
     summaryDebt: "Cartera total:",
     summaryCashBalance: "💰 Saldo de caja:",
     summaryFooter: "_Generado desde Parcela Jaslico_",
+    // Lot-specific report
+    lotReportCopy: "Copiar Resumen del Lote",
+    lotReportTitle: "📊 *ESTADO DE CUENTA*",
+    lotReportLotPrefix: "🏡 *Lote",
+    lotReportInitialBalance: "📋 *Saldo inicial (obras):*",
+    lotReportMaintenance: "🔧 *MANTENIMIENTO*",
+    lotReportWorks: "🏗️ *OBRAS*",
+    lotReportTotalQuota: "  Total cuotas:",
+    lotReportPaid: "  💵 Pagado:",
+    lotReportOwed: "  🔴 Debe:",
+    lotReportTotalOwed: "💰 *Total adeudado:*",
+    lotReportCurrentStatus: "✅ *Al día*",
+    lotReportDate: "📅",
   },
 
   // Date and time

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -200,6 +200,7 @@ export const translations = {
     noQuotasConfigured: "No hay cuotas configuradas",
     quotaSummary: "Resumen de Cuotas",
     viewQuotas: "Ver cuotas",
+    quotaBreakdown: "Estado de Cuotas",
 
     // Grid headers
     maintenanceContributions: "Aportes de Mantenimiento",
@@ -462,6 +463,9 @@ export const translations = {
     lotReportTotalOwed: "💰 *Total adeudado:*",
     lotReportCurrentStatus: "✅ *Al día*",
     lotReportDate: "📅",
+    lotReportQuotaPaid: "✅",
+    lotReportQuotaOwed: "🔴",
+    lotReportQuotaPartial: "⚠️",
   },
 
   // Date and time

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -291,3 +291,102 @@ export function getStatusColor(status: LotPaymentStatus): string {
   }
 }
 
+export interface QuotaLineStatus {
+  id: string;
+  label: string;
+  quotaType: "maintenance" | "works" | "initial";
+  amount: number;
+  paidAmount: number;
+  status: "paid" | "partial" | "owed";
+}
+
+/**
+ * Builds a per-quota paid/owed breakdown for a lot.
+ * Uses oldest-debt-first allocation: contributions are applied to the earliest
+ * quotas first. Works quotas include an optional initial-debt entry at the top.
+ */
+export function buildQuotaBreakdown(
+  quotaConfigs: { id: string; quotaType: string; amount: number; description: string | null; dueDate: Date | null }[],
+  contributions: { type: string; amount: number }[],
+  lot: { initialWorksDebt: number; exemptionEndDate?: Date | string | null }
+): QuotaLineStatus[] {
+  const today = new Date();
+  const activeFrom = lot.exemptionEndDate ? new Date(lot.exemptionEndDate) : null;
+
+  const applicable = quotaConfigs.filter((q) => {
+    if (!q.dueDate) return false;
+    const due = new Date(q.dueDate);
+    if (due > today) return false;
+    if (activeFrom && due < activeFrom) return false;
+    return true;
+  });
+
+  const maintenanceQuotas = applicable
+    .filter((q) => q.quotaType === "maintenance")
+    .sort((a, b) => new Date(a.dueDate!).getTime() - new Date(b.dueDate!).getTime());
+
+  const worksQuotas = applicable
+    .filter((q) => q.quotaType === "works")
+    .sort((a, b) => new Date(a.dueDate!).getTime() - new Date(b.dueDate!).getTime());
+
+  const maintenancePaid = contributions
+    .filter((c) => c.type === "maintenance")
+    .reduce((s, c) => s + c.amount, 0);
+
+  const worksPaid = contributions
+    .filter((c) => c.type === "works")
+    .reduce((s, c) => s + c.amount, 0);
+
+  const result: QuotaLineStatus[] = [];
+
+  // --- Maintenance ---
+  let remaining = maintenancePaid;
+  for (const q of maintenanceQuotas) {
+    const label = q.description || formatQuotaDateLabel(q.dueDate!);
+    if (remaining >= q.amount) {
+      result.push({ id: q.id, label, quotaType: "maintenance", amount: q.amount, paidAmount: q.amount, status: "paid" });
+      remaining -= q.amount;
+    } else if (remaining > 0) {
+      result.push({ id: q.id, label, quotaType: "maintenance", amount: q.amount, paidAmount: remaining, status: "partial" });
+      remaining = 0;
+    } else {
+      result.push({ id: q.id, label, quotaType: "maintenance", amount: q.amount, paidAmount: 0, status: "owed" });
+    }
+  }
+
+  // --- Works (initial debt first, then quotas) ---
+  let remainingWorks = worksPaid;
+  if (lot.initialWorksDebt > 0) {
+    const debt = lot.initialWorksDebt;
+    if (remainingWorks >= debt) {
+      result.push({ id: "initial", label: "Saldo inicial", quotaType: "initial", amount: debt, paidAmount: debt, status: "paid" });
+      remainingWorks -= debt;
+    } else if (remainingWorks > 0) {
+      result.push({ id: "initial", label: "Saldo inicial", quotaType: "initial", amount: debt, paidAmount: remainingWorks, status: "partial" });
+      remainingWorks = 0;
+    } else {
+      result.push({ id: "initial", label: "Saldo inicial", quotaType: "initial", amount: debt, paidAmount: 0, status: "owed" });
+    }
+  }
+  for (const q of worksQuotas) {
+    const label = q.description || formatQuotaDateLabel(q.dueDate!);
+    if (remainingWorks >= q.amount) {
+      result.push({ id: q.id, label, quotaType: "works", amount: q.amount, paidAmount: q.amount, status: "paid" });
+      remainingWorks -= q.amount;
+    } else if (remainingWorks > 0) {
+      result.push({ id: q.id, label, quotaType: "works", amount: q.amount, paidAmount: remainingWorks, status: "partial" });
+      remainingWorks = 0;
+    } else {
+      result.push({ id: q.id, label, quotaType: "works", amount: q.amount, paidAmount: 0, status: "owed" });
+    }
+  }
+
+  return result;
+}
+
+function formatQuotaDateLabel(dueDate: Date | string): string {
+  const d = new Date(dueDate);
+  const months = ["Ene", "Feb", "Mar", "Abr", "May", "Jun", "Jul", "Ago", "Sep", "Oct", "Nov", "Dic"];
+  return `${months[d.getMonth()]} ${d.getFullYear()}`;
+}
+


### PR DESCRIPTION
## Summary

Adds functionality to generate and copy WhatsApp-formatted lot debt reports with detailed quota breakdowns. Includes a new quota breakdown table in the lot detail view showing payment status for each maintenance and works quota.

## Key Changes

- **New Component**: `WhatsAppLotReportButton` - Generates formatted lot reports for WhatsApp sharing with copy-to-clipboard functionality
- **New Utility Function**: `buildQuotaBreakdown()` - Calculates per-quota payment status using oldest-debt-first allocation strategy
- **New Interface**: `QuotaLineStatus` - Represents individual quota payment status with amount, paid amount, and status
- **Enhanced LotDetailView**: 
  - Integrates WhatsApp report button in lot header
  - Displays new quota breakdown table showing maintenance and works quotas with payment status
  - Accepts `quotaConfigs` prop to build breakdown data
- **Updated Translations**: Added WhatsApp report-related translation keys including lot report title, quota status indicators, and footer text

## Implementation Details

- Quota breakdown uses oldest-debt-first allocation: payments are applied to earliest quotas first
- Works quotas include optional initial-debt entry ("Saldo inicial") at the top
- Report filters quotas by due date and exemption status
- Copy-to-clipboard includes visual feedback (green for success, red for error) with 2-second timeout
- Quota breakdown table uses alternating row colors and status badges with emoji indicators (✅ paid, ⚠️ partial, 🔴 owed)
- All user-facing text sourced from translations.ts following project standards

https://claude.ai/code/session_01PEaxbc1esZDyHopzx3FkYT