### PR TITLE
Fix advance quota payment allocation for future quotas

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -313,10 +313,11 @@ export function buildQuotaBreakdown(
   const today = new Date();
   const activeFrom = lot.exemptionEndDate ? new Date(lot.exemptionEndDate) : null;
 
+  // Include all quotas (past and future) so advance payments are allocated correctly.
+  // Future unpaid quotas are filtered out at the end.
   const applicable = quotaConfigs.filter((q) => {
     if (!q.dueDate) return false;
     const due = new Date(q.dueDate);
-    if (due > today) return false;
     if (activeFrom && due < activeFrom) return false;
     return true;
   });
@@ -381,7 +382,17 @@ export function buildQuotaBreakdown(
     }
   }
 
-  return result;
+  // Show all past/current-due quotas. For future quotas, only show if paid or
+  // partially paid (i.e. the owner pre-paid in advance).
+  const quotaMap = new Map(quotaConfigs.map((q) => [q.id, q]));
+  return result.filter((item) => {
+    if (item.id === "initial") return true;
+    const quota = quotaMap.get(item.id);
+    if (!quota?.dueDate) return true;
+    const due = new Date(quota.dueDate);
+    if (due <= today) return true;
+    return item.status === "paid" || item.status === "partial";
+  });
 }
 
 function formatQuotaDateLabel(dueDate: Date | string): string {


### PR DESCRIPTION
## Summary

Fixed quota breakdown calculation to properly allocate advance payments across future quotas. Previously, future quotas were filtered out during the applicable quota selection, preventing advance payments from being correctly distributed to unpaid future quotas.

## Key Changes

- **Removed future quota filter during applicable selection**: Changed the quota filtering logic to include all quotas (past and future) so that advance payments can be properly allocated across the entire quota timeline
- **Added post-processing filter for result display**: Implemented a new filter at the end of `buildQuotaBreakdown()` that:
  - Shows all past and current-due quotas regardless of payment status
  - Shows future quotas only if they have been paid or partially paid (indicating advance payment)
  - Always includes the "initial" quota item
- **Added clarifying comments**: Documented the two-phase approach (include all for calculation, filter for display)

## Implementation Details

The fix separates concerns into two phases:
1. **Calculation phase**: Include all quotas to ensure advance payments are correctly distributed
2. **Display phase**: Filter results to show only relevant quotas to the user (past/current-due always shown, future only if paid/partial)

This ensures that when a user makes an advance payment, it gets properly allocated to future quota periods while maintaining a clean display of only applicable quotas.

https://claude.ai/code/session_01T5F68E896hNTE5F2t2MqVA