### PR TITLE
feat: filter WhatsApp lot report payments by current year

### DIFF
--- a/src/components/shared/WhatsAppLotReportButton.tsx
+++ b/src/components/shared/WhatsAppLotReportButton.tsx
@@ -88,8 +88,7 @@ function generateLotReport(
       const date = formatDateForDisplay(new Date(c.date));
       const type = getPaymentTypeLabel(c.type);
       const amount = formatCurrency(c.amount);
-      const receipt = c.receiptNumber ? ` | ${t.lotReportPaymentReceipt} ${c.receiptNumber}` : "";
-      lines.push(`  ${t.lotReportDate} ${date} | [${type}] ${c.description} | ${amount}${receipt}`);
+      lines.push(`  ${t.lotReportDate} ${date} | [${type}] ${c.description} | ${amount}`);
     }
   }
   lines.push("");

--- a/src/components/shared/WhatsAppLotReportButton.tsx
+++ b/src/components/shared/WhatsAppLotReportButton.tsx
@@ -3,6 +3,8 @@
 import { useRef, useState } from "react";
 import { MessageSquare } from "lucide-react";
 import { Button } from "@/components/ui/Button";
+import { Checkbox } from "@/components/ui/Checkbox";
+import { Label } from "@/components/ui/Label";
 import { LotDebtDetail } from "@/types/quotas.types";
 import { Contribution } from "@/types/contributions.types";
 import { QuotaLineStatus, formatCurrency, formatDateForDisplay } from "@/lib/utils";
@@ -109,6 +111,8 @@ function generateLotReport(
 
 type CopyStatus = "idle" | "copied" | "error";
 
+const CURRENT_YEAR = new Date().getFullYear();
+
 export default function WhatsAppLotReportButton({
   lotNumber,
   owner,
@@ -117,10 +121,15 @@ export default function WhatsAppLotReportButton({
   contributions,
 }: WhatsAppLotReportButtonProps) {
   const [status, setStatus] = useState<CopyStatus>("idle");
+  const [currentYearOnly, setCurrentYearOnly] = useState(true);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  const filteredContributions = currentYearOnly
+    ? contributions.filter((c) => new Date(c.date).getFullYear() === CURRENT_YEAR)
+    : contributions;
+
   async function handleClick() {
-    const text = generateLotReport(lotNumber, owner, debtDetail, quotaBreakdown, contributions);
+    const text = generateLotReport(lotNumber, owner, debtDetail, quotaBreakdown, filteredContributions);
     try {
       await navigator.clipboard.writeText(text);
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
@@ -141,20 +150,35 @@ export default function WhatsAppLotReportButton({
         : t.lotReportCopy;
 
   return (
-    <Button
-      variant="outline"
-      size="sm"
-      onClick={handleClick}
-      className={
-        status === "copied"
-          ? "border-green-500 text-green-600"
-          : status === "error"
-            ? "border-red-500 text-red-600"
-            : ""
-      }
-    >
-      <MessageSquare className="mr-2 h-4 w-4" />
-      {label}
-    </Button>
+    <div className="flex flex-col items-end gap-1.5">
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={handleClick}
+        className={
+          status === "copied"
+            ? "border-green-500 text-green-600"
+            : status === "error"
+              ? "border-red-500 text-red-600"
+              : ""
+        }
+      >
+        <MessageSquare className="mr-2 h-4 w-4" />
+        {label}
+      </Button>
+      <div className="flex items-center gap-1.5">
+        <Checkbox
+          id="whatsapp-year-filter"
+          checked={currentYearOnly}
+          onCheckedChange={(checked) => setCurrentYearOnly(!!checked)}
+        />
+        <Label
+          htmlFor="whatsapp-year-filter"
+          className="text-muted-foreground cursor-pointer text-xs"
+        >
+          {t.lotReportCurrentYearOnly} ({CURRENT_YEAR})
+        </Label>
+      </div>
+    </div>
   );
 }

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -476,6 +476,7 @@ export const translations = {
     // Payments section
     lotReportPayments: "💸 *PAGOS REALIZADOS*",
     lotReportNoPayments: "Sin pagos registrados",
+    lotReportCurrentYearOnly: "Solo año actual",
     lotReportPaymentTypeMaintenance: "Mant.",
     lotReportPaymentTypeWorks: "Obras",
     lotReportPaymentTypeOthers: "Otros",

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -475,7 +475,6 @@ export const translations = {
     lotReportQuotaPartial: "⚠️",
     // Payments section
     lotReportPayments: "💸 *PAGOS REALIZADOS*",
-    lotReportPaymentReceipt: "Comp:",
     lotReportNoPayments: "Sin pagos registrados",
     lotReportPaymentTypeMaintenance: "Mant.",
     lotReportPaymentTypeWorks: "Obras",


### PR DESCRIPTION
## Summary

- Remove receipt number (`Comp: xxx`) from each payment line — it added visual noise.
- Add a checkbox below the copy button labeled **"Solo año actual (2026)"**, checked by default — the report only includes payments from the current year, keeping the message short.
- Uncheck to include the full payment history across all years.
- Add `lotReportCurrentYearOnly` translation key; remove unused `lotReportPaymentReceipt` key.

No changes to the quota breakdown section — that always reflects the full state.