### PR TITLE
fix: correct date timezone shift in WhatsApp lot report

### DIFF
--- a/src/components/shared/WhatsAppLotReportButton.tsx
+++ b/src/components/shared/WhatsAppLotReportButton.tsx
@@ -7,7 +7,7 @@ import { Checkbox } from "@/components/ui/Checkbox";
 import { Label } from "@/components/ui/Label";
 import { LotDebtDetail } from "@/types/quotas.types";
 import { Contribution } from "@/types/contributions.types";
-import { QuotaLineStatus, formatCurrency, formatDateForDisplay } from "@/lib/utils";
+import { QuotaLineStatus, formatCurrency, formatDateForDisplay, parseLocalDate } from "@/lib/utils";
 import { translations } from "@/lib/translations";
 
 const t = translations.whatsapp;
@@ -80,14 +80,14 @@ function generateLotReport(
   // Payments made section
   lines.push(t.lotReportPayments);
   const sortedContributions = [...contributions].sort(
-    (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
+    (a, b) => a.date.localeCompare(b.date)
   );
 
   if (sortedContributions.length === 0) {
     lines.push(`  ${t.lotReportNoPayments}`);
   } else {
     for (const c of sortedContributions) {
-      const date = formatDateForDisplay(new Date(c.date));
+      const date = formatDateForDisplay(c.date);
       const type = getPaymentTypeLabel(c.type);
       const amount = formatCurrency(c.amount);
       lines.push(`  ${t.lotReportDate} ${date} | [${type}] ${c.description} | ${amount}`);
@@ -125,7 +125,7 @@ export default function WhatsAppLotReportButton({
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const filteredContributions = currentYearOnly
-    ? contributions.filter((c) => new Date(c.date).getFullYear() === CURRENT_YEAR)
+    ? contributions.filter((c) => parseLocalDate(c.date).getFullYear() === CURRENT_YEAR)
     : contributions;
 
   const filteredQuotaBreakdown = currentYearOnly


### PR DESCRIPTION
## Problem

The WhatsApp lot report was displaying contribution dates one day earlier than the actual date. For example, a payment made on 05/08/2026 appeared as 04/08/2026 in the report.

## Root cause

`formatDateForDisplay(new Date(c.date))` was parsing the YYYY-MM-DD date string as UTC midnight (`2026-08-05T00:00:00Z`). In Colombia (UTC-5), that UTC midnight equals 7pm of the previous day, so `getDate()` returned the wrong day.

## Changes

**`src/components/shared/WhatsAppLotReportButton.tsx`**
- Pass `c.date` string directly to `formatDateForDisplay` instead of wrapping it in `new Date()` — the function already has a local-date parser for YYYY-MM-DD strings.
- Replace `new Date(a.date).getTime()` sort with `a.date.localeCompare(b.date)` — YYYY-MM-DD strings sort correctly lexicographically and avoids the UTC trap.
- Use `parseLocalDate(c.date).getFullYear()` for the year filter so Jan 1 contributions are not misassigned to the prior year.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QzBqvPC81Woe896hWmrtGH)_